### PR TITLE
Add the diagnostic and fix model

### DIFF
--- a/src/housestyle/domain/__init__.py
+++ b/src/housestyle/domain/__init__.py
@@ -1,13 +1,20 @@
+from .diagnostic import Diagnostic, Fix, FixKind, Report, RuleMeta, Severity
 from .document import Document
 from .position import Encoding, Position, PositionMap, SourceRange
 from .text import TextEdit, apply_edits
 
 
 __all__ = [
+    'Diagnostic',
     'Document',
     'Encoding',
+    'Fix',
+    'FixKind',
     'Position',
     'PositionMap',
+    'Report',
+    'RuleMeta',
+    'Severity',
     'SourceRange',
     'TextEdit',
     'apply_edits',

--- a/src/housestyle/domain/diagnostic.py
+++ b/src/housestyle/domain/diagnostic.py
@@ -1,0 +1,116 @@
+import dataclasses
+import enum
+
+from .position import SourceRange
+from .text import TextEdit
+
+
+class Severity(enum.IntEnum):
+    SUGGESTION = 1
+    WARNING = 2
+    ERROR = 3
+
+
+class FixKind(enum.Enum):
+    TARGETED = 'targeted'
+    REFLOW = 'reflow'
+    REWRITE = 'rewrite'
+
+    @property
+    def is_mechanical(self) -> bool:
+        return self is not FixKind.REWRITE
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Fix:
+    kind: FixKind
+    edits: tuple[TextEdit, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.kind is FixKind.REWRITE and self.edits:
+            raise ValueError('A REWRITE fix carries no edits, only the author can resolve it')
+        if self.kind.is_mechanical and not self.edits:
+            raise ValueError(f'A {self.kind.name} fix must carry at least one edit')
+
+    @classmethod
+    def targeted(cls, *edits: TextEdit) -> 'Fix':
+        return cls(FixKind.TARGETED, edits)
+
+    @classmethod
+    def reflow(cls, *edits: TextEdit) -> 'Fix':
+        return cls(FixKind.REFLOW, edits)
+
+    @classmethod
+    def rewrite(cls) -> 'Fix':
+        return cls(FixKind.REWRITE)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RuleMeta:
+    rule_id: str
+    summary: str
+    fix_kind: FixKind
+    default_severity: Severity = Severity.ERROR
+    source: str = 'housestyle'
+
+    def __post_init__(self) -> None:
+        if not self.rule_id:
+            raise ValueError('A rule needs an id')
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Diagnostic:
+    rule_id: str
+    range: SourceRange
+    message: str
+    severity: Severity = Severity.ERROR
+    fix: Fix | None = None
+    source: str = 'housestyle'
+
+    def __post_init__(self) -> None:
+        if not self.message:
+            raise ValueError(f'Rule {self.rule_id} produced an empty message')
+
+    @property
+    def is_mechanical(self) -> bool:
+        return self.fix is not None and self.fix.kind.is_mechanical
+
+    @property
+    def needs_author(self) -> bool:
+        return not self.is_mechanical
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Report:
+    diagnostics: tuple[Diagnostic, ...] = ()
+    unavailable_sources: tuple[str, ...] = ()
+
+    @property
+    def mechanical(self) -> tuple[Diagnostic, ...]:
+        return tuple(item for item in self.diagnostics if item.is_mechanical)
+
+    @property
+    def needing_author(self) -> tuple[Diagnostic, ...]:
+        return tuple(item for item in self.diagnostics if item.needs_author)
+
+    @property
+    def is_clean(self) -> bool:
+        return not self.diagnostics
+
+    def by_kind(self, kind: FixKind) -> tuple[Diagnostic, ...]:
+        return tuple(item for item in self.diagnostics if item.fix is not None and item.fix.kind is kind)
+
+    def merged_with(self, other: 'Report') -> 'Report':
+        seen: set[tuple[str, int, int]] = set()
+        combined: list[Diagnostic] = []
+        for item in (*self.diagnostics, *other.diagnostics):
+            key = (item.rule_id, item.range.start, item.range.end)
+            if key in seen:
+                continue
+            seen.add(key)
+            combined.append(item)
+        combined.sort(key=lambda item: (item.range.start, item.rule_id))
+        return Report(
+            tuple(combined),
+            tuple(dict.fromkeys((*self.unavailable_sources, *other.unavailable_sources))),
+        )

--- a/tests/test_diagnostic.py
+++ b/tests/test_diagnostic.py
@@ -1,0 +1,101 @@
+import pytest
+
+from housestyle.domain import Diagnostic, Fix, FixKind, Report, RuleMeta, Severity, SourceRange, TextEdit
+
+
+def edit(start: int = 0, end: int = 1, new_text: str = 'x') -> TextEdit:
+    return TextEdit(SourceRange(start, end), new_text)
+
+
+def diagnostic(rule_id: str = 'wrap-point', start: int = 0, fix: Fix | None = None) -> Diagnostic:
+    return Diagnostic(rule_id=rule_id, range=SourceRange(start, start + 1), message='something', fix=fix)
+
+
+def test_rewrite_carries_no_edits() -> None:
+    assert Fix.rewrite().edits == ()
+    with pytest.raises(ValueError, match='no edits'):
+        Fix(FixKind.REWRITE, (edit(),))
+
+
+@pytest.mark.parametrize('kind', [FixKind.TARGETED, FixKind.REFLOW])
+def test_mechanical_fixes_must_carry_edits(kind: FixKind) -> None:
+    with pytest.raises(ValueError, match='at least one edit'):
+        Fix(kind, ())
+
+
+def test_only_rewrite_is_not_mechanical() -> None:
+    assert FixKind.TARGETED.is_mechanical
+    assert FixKind.REFLOW.is_mechanical
+    assert not FixKind.REWRITE.is_mechanical
+
+
+def test_a_diagnostic_without_a_fix_needs_the_author() -> None:
+    assert diagnostic().needs_author
+    assert not diagnostic().is_mechanical
+
+
+def test_a_rewrite_diagnostic_needs_the_author() -> None:
+    assert diagnostic(fix=Fix.rewrite()).needs_author
+
+
+@pytest.mark.parametrize('fix', [Fix.targeted(edit()), Fix.reflow(edit())])
+def test_a_mechanical_diagnostic_does_not_need_the_author(fix: Fix) -> None:
+    assert diagnostic(fix=fix).is_mechanical
+    assert not diagnostic(fix=fix).needs_author
+
+
+def test_an_empty_message_is_rejected() -> None:
+    with pytest.raises(ValueError, match='empty message'):
+        Diagnostic(rule_id='r', range=SourceRange(0, 1), message='')
+
+
+def test_a_rule_needs_an_id() -> None:
+    with pytest.raises(ValueError, match='needs an id'):
+        RuleMeta(rule_id='', summary='s', fix_kind=FixKind.REFLOW)
+
+
+def test_rule_meta_defaults_to_error() -> None:
+    meta = RuleMeta(rule_id='wrap-point', summary='s', fix_kind=FixKind.REFLOW)
+    assert meta.default_severity is Severity.ERROR
+    assert meta.source == 'housestyle'
+
+
+def test_report_partitions_by_who_can_fix() -> None:
+    mechanical = diagnostic('line-width', 0, Fix.reflow(edit()))
+    authored = diagnostic('stub-fragment', 5, Fix.rewrite())
+    report = Report((mechanical, authored))
+
+    assert report.mechanical == (mechanical,)
+    assert report.needing_author == (authored,)
+    assert report.by_kind(FixKind.REFLOW) == (mechanical,)
+    assert report.by_kind(FixKind.TARGETED) == ()
+    assert not report.is_clean
+
+
+def test_an_empty_report_is_clean() -> None:
+    assert Report().is_clean
+
+
+def test_merging_deduplicates_identical_findings_and_sorts_by_position() -> None:
+    late = diagnostic('no-em-dash', 40)
+    early = diagnostic('no-em-dash', 10)
+    duplicate = diagnostic('no-em-dash', 10)
+
+    merged = Report((late,)).merged_with(Report((duplicate, early)))
+
+    assert len(merged.diagnostics) == 2
+    assert [item.range.start for item in merged.diagnostics] == [10, 40]
+
+
+def test_merging_keeps_findings_that_differ_only_by_rule() -> None:
+    merged = Report((diagnostic('no-em-dash', 10),)).merged_with(Report((diagnostic('no-semicolon', 10),)))
+    assert len(merged.diagnostics) == 2
+
+
+def test_merging_records_every_unavailable_source_once() -> None:
+    merged = Report(unavailable_sources=('vale',)).merged_with(Report(unavailable_sources=('vale', 'autocorrect')))
+    assert merged.unavailable_sources == ('vale', 'autocorrect')
+
+
+def test_severity_orders_by_urgency() -> None:
+    assert Severity.ERROR > Severity.WARNING > Severity.SUGGESTION


### PR DESCRIPTION
The output vocabulary every frontend and adapter speaks.

`FixKind` classifies a finding by **who can resolve it**, not by whether a fix exists. That is the axis the whole agent-feedback model turns on.

| Kind | Who resolves it | Reaches the agent |
| --- | --- | --- |
| `TARGETED` | the tool, silently | no |
| `REFLOW` | the tool, silently | no |
| `REWRITE` | only the author | yes |

The constructor enforces the split rather than documenting it. A `REWRITE` carrying edits is rejected, and so is a mechanical fix carrying none, so the taxonomy cannot quietly become decoration.

`Report` partitions on the same axis and merges by rule and range, which is what lets native rules and delegated linters land in one place without double reporting. It also tracks `unavailable_sources`, so a run degraded by a missing tool is visible instead of silently thinner.

86 tests.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)