### PR TITLE
Add CommentBlock and Prose

### DIFF
--- a/src/housestyle/domain/__init__.py
+++ b/src/housestyle/domain/__init__.py
@@ -1,10 +1,18 @@
+from .comment import CommentBlock, CommentForm, CommentLine, CommentPlacement, SymbolRef, Visibility
 from .diagnostic import Diagnostic, Fix, FixKind, Report, RuleMeta, Severity
 from .document import Document
 from .position import Encoding, Position, PositionMap, SourceRange
+from .prose import BreakPoint, BreakStrength, Prose, Sentence
 from .text import TextEdit, apply_edits
 
 
 __all__ = [
+    'BreakPoint',
+    'BreakStrength',
+    'CommentBlock',
+    'CommentForm',
+    'CommentLine',
+    'CommentPlacement',
     'Diagnostic',
     'Document',
     'Encoding',
@@ -12,10 +20,14 @@ __all__ = [
     'FixKind',
     'Position',
     'PositionMap',
+    'Prose',
     'Report',
     'RuleMeta',
+    'Sentence',
     'Severity',
     'SourceRange',
+    'SymbolRef',
     'TextEdit',
+    'Visibility',
     'apply_edits',
 ]

--- a/src/housestyle/domain/comment.py
+++ b/src/housestyle/domain/comment.py
@@ -1,0 +1,103 @@
+import dataclasses
+import enum
+
+from .position import SourceRange
+from .prose import Prose
+from .text import TextEdit
+
+
+class CommentForm(enum.Enum):
+    LINE = 'line'
+    BLOCK = 'block'
+    DOC = 'doc'
+
+
+class CommentPlacement(enum.Enum):
+    FILE_HEADER = 'file-header'
+    LEADING_DECLARATION = 'leading-declaration'
+    INLINE_BODY = 'inline-body'
+    TRAILING = 'trailing'
+
+
+class Visibility(enum.Enum):
+    PUBLIC = 'public'
+    INTERNAL = 'internal'
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SymbolRef:
+    name: str
+    kind: str
+    visibility: Visibility
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CommentLine:
+    range: SourceRange
+    indent: str
+    marker: str
+    payload: str
+
+    @property
+    def physical_width(self) -> int:
+        return len(self.indent) + len(self.marker) + len(self.payload)
+
+    @property
+    def prefix_width(self) -> int:
+        return len(self.indent) + len(self.marker)
+
+    def rendered(self) -> str:
+        if not self.payload:
+            return (self.indent + self.marker).rstrip()
+        return self.indent + self.marker + self.payload
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CommentBlock:
+    range: SourceRange
+    lines: tuple[CommentLine, ...]
+    form: CommentForm
+    placement: CommentPlacement
+    attachment: SymbolRef | None = None
+
+    def __post_init__(self) -> None:
+        if not self.lines:
+            raise ValueError('A comment block needs at least one line')
+
+    @property
+    def line_count(self) -> int:
+        return len(self.lines)
+
+    @property
+    def is_multiline(self) -> bool:
+        return len(self.lines) > 1
+
+    @property
+    def widest_line(self) -> int:
+        return max(line.physical_width for line in self.lines)
+
+    @property
+    def attaches_to_public_symbol(self) -> bool:
+        return self.attachment is not None and self.attachment.visibility is Visibility.PUBLIC
+
+    def prose(self) -> Prose:
+        return Prose('\n'.join(line.payload.strip() for line in self.lines))
+
+    def with_payloads(self, payloads: tuple[str, ...]) -> 'CommentBlock':
+        if not payloads:
+            raise ValueError('A comment block needs at least one line')
+        template = self.lines[0]
+        rebuilt = tuple(
+            dataclasses.replace(
+                self.lines[index] if index < len(self.lines) else template,
+                payload=payload,
+            )
+            for index, payload in enumerate(payloads)
+        )
+        return dataclasses.replace(self, lines=rebuilt)
+
+    def render(self) -> str:
+        return '\n'.join(line.rendered() for line in self.lines)
+
+    def as_edit(self) -> TextEdit:
+        return TextEdit(self.range, self.render())

--- a/src/housestyle/domain/prose.py
+++ b/src/housestyle/domain/prose.py
@@ -1,0 +1,126 @@
+import dataclasses
+import enum
+import re
+
+
+ABBREVIATIONS = frozenset(
+    {
+        'e.g',
+        'i.e',
+        'etc',
+        'vs',
+        'cf',
+        'al',
+        'approx',
+        'no',
+        'fig',
+        'ca',
+        'resp',
+    }
+)
+
+_SENTENCE_END = re.compile(r'[.!?]')
+_TRAILING_WORD = re.compile(r'([A-Za-z][A-Za-z.]*)$')
+_URL = re.compile(r'\b(?:https?://|www\.)\S+')
+_CODE_SPAN = re.compile(r'`[^`]*`')
+
+
+class BreakStrength(enum.IntEnum):
+    COMMA = 1
+    SENTENCE = 2
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class BreakPoint:
+    offset: int
+    strength: BreakStrength
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Sentence:
+    text: str
+    offset: int
+
+    @property
+    def end(self) -> int:
+        return self.offset + len(self.text)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Prose:
+    text: str
+
+    @property
+    def physical_lines(self) -> tuple[str, ...]:
+        return tuple(self.text.split('\n'))
+
+    @property
+    def flattened(self) -> str:
+        return ' '.join(line.strip() for line in self.physical_lines if line.strip())
+
+    def sentences(self) -> tuple[Sentence, ...]:
+        text = self.flattened
+        if not text:
+            return ()
+        protected = self._protected_spans(text)
+        found: list[Sentence] = []
+        start = 0
+        for match in _SENTENCE_END.finditer(text):
+            end = match.end()
+            if self._is_protected(match.start(), protected):
+                continue
+            if not self._terminates_a_sentence(text, match.start()):
+                continue
+            found.append(Sentence(text[start:end].strip(), start))
+            start = end
+            while start < len(text) and text[start] == ' ':
+                start += 1
+        if start < len(text):
+            found.append(Sentence(text[start:].strip(), start))
+        return tuple(item for item in found if item.text)
+
+    def break_candidates(self) -> tuple[BreakPoint, ...]:
+        text = self.flattened
+        protected = self._protected_spans(text)
+        points: list[BreakPoint] = []
+        for match in re.finditer(r'[.!?,]', text):
+            if self._is_protected(match.start(), protected):
+                continue
+            if match.group() == ',':
+                points.append(BreakPoint(match.end(), BreakStrength.COMMA))
+            elif self._terminates_a_sentence(text, match.start()):
+                points.append(BreakPoint(match.end(), BreakStrength.SENTENCE))
+        return tuple(points)
+
+    def is_break_legal(self, offset: int) -> bool:
+        return any(point.offset == offset for point in self.break_candidates())
+
+    def _protected_spans(self, text: str) -> tuple[tuple[int, int], ...]:
+        spans = [(match.start(), match.end()) for match in _URL.finditer(text)]
+        spans.extend((match.start(), match.end()) for match in _CODE_SPAN.finditer(text))
+        return tuple(spans)
+
+    def _is_protected(self, offset: int, spans: tuple[tuple[int, int], ...]) -> bool:
+        return any(start <= offset < end for start, end in spans)
+
+    def _terminates_a_sentence(self, text: str, offset: int) -> bool:
+        if text[offset] != '.':
+            return self._followed_by_break(text, offset)
+        if offset + 1 < len(text) and text[offset + 1].isdigit():
+            return False
+        if offset > 0 and text[offset - 1].isdigit() and offset + 1 < len(text) and text[offset + 1].isdigit():
+            return False
+        match = _TRAILING_WORD.search(text[:offset])
+        if match and match.group(1).lower().rstrip('.') in ABBREVIATIONS:
+            return False
+        if match and len(match.group(1).replace('.', '')) == 1:
+            return False
+        return self._followed_by_break(text, offset)
+
+    def _followed_by_break(self, text: str, offset: int) -> bool:
+        rest = text[offset + 1 :]
+        if not rest:
+            return True
+        if rest[0] in '"\')]}':
+            rest = rest[1:]
+        return not rest or rest[0] == ' '

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -1,0 +1,104 @@
+import pytest
+
+from housestyle.domain import (
+    CommentBlock,
+    CommentForm,
+    CommentLine,
+    CommentPlacement,
+    SourceRange,
+    SymbolRef,
+    Visibility,
+)
+
+
+def line(payload: str, indent: str = '  ', marker: str = '// ', start: int = 0) -> CommentLine:
+    return CommentLine(SourceRange(start, start + 1), indent, marker, payload)
+
+
+def block(*payloads: str, **kwargs: object) -> CommentBlock:
+    defaults: dict[str, object] = {
+        'range': SourceRange(0, 10),
+        'lines': tuple(line(payload) for payload in payloads),
+        'form': CommentForm.LINE,
+        'placement': CommentPlacement.INLINE_BODY,
+    }
+    defaults.update(kwargs)
+    return CommentBlock(**defaults)  # pyright: ignore[reportArgumentType]
+
+
+def test_a_block_needs_at_least_one_line() -> None:
+    with pytest.raises(ValueError, match='at least one line'):
+        CommentBlock(
+            range=SourceRange(0, 1),
+            lines=(),
+            form=CommentForm.LINE,
+            placement=CommentPlacement.INLINE_BODY,
+        )
+
+
+def test_physical_width_counts_indent_and_marker_not_just_payload() -> None:
+    subject = line('payload', indent=' ' * 40, marker='// ')
+    assert len(subject.payload) == 7
+    assert subject.physical_width == 50
+    assert subject.prefix_width == 43
+
+
+def test_widest_line_is_measured_across_the_block() -> None:
+    subject = block('short', 'a much longer payload here')
+    assert subject.widest_line == len('  // ') + len('a much longer payload here')
+
+
+def test_multiline_detection() -> None:
+    assert not block('only').is_multiline
+    assert block('first', 'second').is_multiline
+    assert block('first', 'second').line_count == 2
+
+
+def test_prose_strips_markers_and_joins_lines() -> None:
+    subject = block('cap the size to the limit,', 'an unbounded value faults')
+    assert subject.prose().physical_lines == ('cap the size to the limit,', 'an unbounded value faults')
+    assert subject.prose().flattened == 'cap the size to the limit, an unbounded value faults'
+
+
+def test_rendering_round_trips_the_prefix() -> None:
+    assert block('alpha', 'beta').render() == '  // alpha\n  // beta'
+
+
+def test_an_empty_payload_renders_without_trailing_space() -> None:
+    assert block('').render() == '  //'
+
+
+def test_with_payloads_returns_a_new_block_and_leaves_the_original_alone() -> None:
+    original = block('one', 'two')
+    rewrapped = original.with_payloads(('single line now',))
+
+    assert rewrapped is not original
+    assert original.line_count == 2
+    assert rewrapped.line_count == 1
+    assert rewrapped.render() == '  // single line now'
+
+
+def test_with_payloads_can_grow_the_block_using_the_first_line_prefix() -> None:
+    grown = block('one').with_payloads(('one', 'two', 'three'))
+    assert grown.render() == '  // one\n  // two\n  // three'
+
+
+def test_with_payloads_rejects_an_empty_result() -> None:
+    with pytest.raises(ValueError, match='at least one line'):
+        block('one').with_payloads(())
+
+
+def test_public_attachment_is_reported() -> None:
+    public = block('doc', attachment=SymbolRef('buildProposal', 'function', Visibility.PUBLIC))
+    internal = block('doc', attachment=SymbolRef('_helper', 'function', Visibility.INTERNAL))
+
+    assert public.attaches_to_public_symbol
+    assert not internal.attaches_to_public_symbol
+    assert not block('doc').attaches_to_public_symbol
+
+
+def test_as_edit_targets_the_block_range() -> None:
+    subject = block('alpha', range=SourceRange(4, 40))
+    edit = subject.as_edit()
+    assert edit.range == SourceRange(4, 40)
+    assert edit.new_text == '  // alpha'

--- a/tests/test_prose.py
+++ b/tests/test_prose.py
@@ -1,0 +1,121 @@
+import pytest
+
+from housestyle.domain.prose import BreakStrength, Prose
+
+
+def texts(prose: Prose) -> list[str]:
+    return [sentence.text for sentence in prose.sentences()]
+
+
+def test_empty_prose_has_no_sentences() -> None:
+    assert Prose('').sentences() == ()
+    assert Prose('   \n  ').sentences() == ()
+
+
+def test_a_single_sentence_stays_whole() -> None:
+    assert texts(Prose('cap the size to the CI limit.')) == ['cap the size to the CI limit.']
+
+
+def test_sentences_split_on_terminators() -> None:
+    prose = Prose('first one. second one! third one? fourth')
+    assert texts(prose) == ['first one.', 'second one!', 'third one?', 'fourth']
+
+
+def test_physical_lines_are_flattened_before_segmentation() -> None:
+    prose = Prose('cap the size to the CI mmap limit,\nan unbounded value faults the runner.')
+    assert texts(prose) == ['cap the size to the CI mmap limit, an unbounded value faults the runner.']
+
+
+@pytest.mark.parametrize(
+    'text',
+    [
+        'use a helper, e.g. the clock, before this runs',
+        'the port, i.e. the interface, lives in domain',
+        'compare vs. the previous value here',
+        'see Smith et al. for the derivation',
+    ],
+)
+def test_abbreviations_do_not_end_a_sentence(text: str) -> None:
+    assert len(Prose(text).sentences()) == 1
+
+
+@pytest.mark.parametrize(
+    'text',
+    [
+        'the cap is 3.14 percent of the budget',
+        'requires version 3.11 or newer to build',
+        'the ratio 0.5 holds across every run',
+    ],
+)
+def test_decimals_do_not_end_a_sentence(text: str) -> None:
+    assert len(Prose(text).sentences()) == 1
+
+
+@pytest.mark.parametrize(
+    'text',
+    [
+        'see https://vale.sh/docs/formats/code for the details',
+        'mirrored at www.example.com/a.b.c today',
+    ],
+)
+def test_urls_do_not_end_a_sentence(text: str) -> None:
+    assert len(Prose(text).sentences()) == 1
+
+
+def test_code_spans_do_not_end_a_sentence() -> None:
+    assert len(Prose('call `obj.method.chain` before the flush').sentences()) == 1
+
+
+def test_an_initial_does_not_end_a_sentence() -> None:
+    assert len(Prose('named after J. Smith originally').sentences()) == 1
+
+
+def test_a_terminator_needs_whitespace_after_it() -> None:
+    assert len(Prose('the file a.ts holds it').sentences()) == 1
+
+
+def test_a_closing_quote_after_a_terminator_still_ends_the_sentence() -> None:
+    assert len(Prose('he said "stop." then left the room.').sentences()) == 2
+
+
+def test_break_candidates_rank_sentence_ends_above_commas() -> None:
+    prose = Prose('cap the size, then flush. retry later')
+    strengths = [point.strength for point in prose.break_candidates()]
+    assert BreakStrength.COMMA in strengths
+    assert BreakStrength.SENTENCE in strengths
+    assert BreakStrength.SENTENCE > BreakStrength.COMMA
+
+
+def test_break_candidates_land_after_the_punctuation() -> None:
+    prose = Prose('alpha, beta')
+    assert [point.offset for point in prose.break_candidates()] == [len('alpha,')]
+
+
+def test_a_sentence_without_a_comma_offers_no_internal_break() -> None:
+    prose = Prose('this sentence runs on without any internal punctuation at all')
+    assert prose.break_candidates() == ()
+
+
+def test_break_legality_is_exact() -> None:
+    prose = Prose('alpha, beta')
+    assert prose.is_break_legal(len('alpha,'))
+    assert not prose.is_break_legal(len('alpha'))
+    assert not prose.is_break_legal(3)
+
+
+def test_urls_offer_no_break_candidates_inside_themselves() -> None:
+    prose = Prose('see https://example.com/a,b,c now')
+    assert prose.break_candidates() == ()
+
+
+def test_sentence_offsets_address_the_flattened_text() -> None:
+    prose = Prose('first one. second one.')
+    first, second = prose.sentences()
+    assert prose.flattened[first.offset : first.end] == 'first one.'
+    assert prose.flattened[second.offset : second.end] == 'second one.'
+
+
+def test_physical_lines_are_preserved_separately() -> None:
+    prose = Prose('one\ntwo\nthree')
+    assert prose.physical_lines == ('one', 'two', 'three')
+    assert prose.flattened == 'one two three'


### PR DESCRIPTION
The two domain objects the layout rules are built on. Both are pure, with no parser and no I/O.

## CommentLine keeps the prefix separate

`indent`, `marker`, and `payload` are distinct fields, so `physical_width` counts all three. This is the gap that made Vale unusable for width: it measures the extracted payload, so a comment indented forty columns reads as clean while the source line runs to 104 characters.

## Prose owns every wrap decision

Marker-stripped content, where no language differences remain. Segmentation protects the cases that produce false sentence boundaries:

- Abbreviations, `e.g.` / `i.e.` / `vs.` / `et al.`
- Decimals, `3.14` and `version 3.11`
- URLs, including paths containing dots and commas
- Code spans in backticks
- Single-letter initials, `J. Smith`

A terminator also only ends a sentence when whitespace follows, so `the file a.ts holds it` stays one sentence.

`break_candidates` ranks sentence ends above commas, which is what policy B needs to decide where a long sentence may split.

## Immutability

`with_payloads` returns a new block rather than mutating, so reflow stays a pure transformation and the original stays available for diffing.

122 tests.

Closes #4
Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)