### PR TITLE
Add the tree-sitter parser and the Python profile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 
-dependencies = []
+dependencies = [
+    "tree-sitter>=0.26.0",
+    "tree-sitter-language-pack>=1.15.8",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/src/housestyle/domain/__init__.py
+++ b/src/housestyle/domain/__init__.py
@@ -1,6 +1,7 @@
 from .comment import CommentBlock, CommentForm, CommentLine, CommentPlacement, SymbolRef, Visibility
 from .diagnostic import Diagnostic, Fix, FixKind, Report, RuleMeta, Severity
 from .document import Document
+from .ports import LanguageProfile, SourceParser
 from .position import Encoding, Position, PositionMap, SourceRange
 from .prose import BreakPoint, BreakStrength, Prose, Sentence
 from .text import TextEdit, apply_edits
@@ -18,6 +19,7 @@ __all__ = [
     'Encoding',
     'Fix',
     'FixKind',
+    'LanguageProfile',
     'Position',
     'PositionMap',
     'Prose',
@@ -25,6 +27,7 @@ __all__ = [
     'RuleMeta',
     'Sentence',
     'Severity',
+    'SourceParser',
     'SourceRange',
     'SymbolRef',
     'TextEdit',

--- a/src/housestyle/domain/comment.py
+++ b/src/housestyle/domain/comment.py
@@ -37,19 +37,20 @@ class CommentLine:
     indent: str
     marker: str
     payload: str
+    suffix: str = ''
 
     @property
     def physical_width(self) -> int:
-        return len(self.indent) + len(self.marker) + len(self.payload)
+        return len(self.indent) + len(self.marker) + len(self.payload) + len(self.suffix)
 
     @property
     def prefix_width(self) -> int:
         return len(self.indent) + len(self.marker)
 
     def rendered(self) -> str:
-        if not self.payload:
+        if not self.payload and not self.suffix:
             return (self.indent + self.marker).rstrip()
-        return self.indent + self.marker + self.payload
+        return self.indent + self.marker + self.payload + self.suffix
 
 
 @dataclasses.dataclass(frozen=True, slots=True)

--- a/src/housestyle/domain/ports.py
+++ b/src/housestyle/domain/ports.py
@@ -1,0 +1,33 @@
+import typing
+
+from .comment import CommentBlock, CommentForm, Visibility
+from .document import Document
+
+
+class LanguageProfile(typing.Protocol):
+    @property
+    def language_id(self) -> str: ...
+
+    @property
+    def extensions(self) -> frozenset[str]: ...
+
+    @property
+    def doc_form_marker(self) -> str: ...
+
+    @property
+    def line_width(self) -> int: ...
+
+    @property
+    def signature_tags(self) -> tuple[str, ...]: ...
+
+    def query(self) -> str: ...
+
+    def visibility_of(self, name: str) -> Visibility: ...
+
+    def split_marker(self, line: str, form: CommentForm) -> tuple[str, str, str, str]: ...
+
+
+class SourceParser(typing.Protocol):
+    def supports(self, language_id: str) -> bool: ...
+
+    def parse(self, document: Document) -> tuple[CommentBlock, ...]: ...

--- a/src/housestyle/infrastructure/__init__.py
+++ b/src/housestyle/infrastructure/__init__.py
@@ -1,0 +1,7 @@
+from .languages import PYTHON
+from .parser import TreeSitterParser
+
+
+DEFAULT_PARSER = TreeSitterParser((PYTHON,))
+
+__all__ = ['DEFAULT_PARSER', 'PYTHON', 'TreeSitterParser']

--- a/src/housestyle/infrastructure/languages/__init__.py
+++ b/src/housestyle/infrastructure/languages/__init__.py
@@ -1,0 +1,4 @@
+from .python import PYTHON, PythonProfile
+
+
+__all__ = ['PYTHON', 'PythonProfile']

--- a/src/housestyle/infrastructure/languages/python.py
+++ b/src/housestyle/infrastructure/languages/python.py
@@ -1,0 +1,54 @@
+import re
+
+from ...domain.comment import CommentForm, Visibility
+
+
+_DOC_DELIMITER = re.compile(r'^([rRbBuUfF]{0,2})("""|\'\'\')')
+_HASH_MARKER = re.compile(r'^(#+\s?)')
+
+QUERY = """
+(comment) @comment
+(module . (string) @docstring)
+(function_definition body: (block . (string) @docstring))
+(class_definition body: (block . (string) @docstring))
+"""
+
+
+class PythonProfile:
+    language_id = 'python'
+    extensions = frozenset({'.py', '.pyi'})
+    doc_form_marker = '"""'
+    line_width = 120
+    signature_tags = ('Args:', 'Returns:', 'Raises:', 'Yields:', ':param', ':return', ':rtype')
+
+    def query(self) -> str:
+        return QUERY
+
+    def visibility_of(self, name: str) -> Visibility:
+        return Visibility.INTERNAL if name.startswith('_') else Visibility.PUBLIC
+
+    def split_marker(self, line: str, form: CommentForm) -> tuple[str, str, str, str]:
+        indent = line[: len(line) - len(line.lstrip())]
+        rest = line[len(indent) :]
+        if form is CommentForm.DOC:
+            return (indent, *self._split_doc(rest))
+        match = _HASH_MARKER.match(rest)
+        if match is None:
+            return indent, '', rest.rstrip(), ''
+        return indent, match.group(1), rest[match.end() :].rstrip(), ''
+
+    def _split_doc(self, rest: str) -> tuple[str, str, str]:
+        opening = _DOC_DELIMITER.match(rest)
+        marker = opening.group(0) if opening else ''
+        body = rest[len(marker) :]
+        delimiter = opening.group(2) if opening else ''
+        suffix = ''
+        for candidate in (delimiter, '"""', "'''"):
+            if candidate and body.endswith(candidate):
+                suffix = candidate
+                body = body[: -len(candidate)]
+                break
+        return marker, body.rstrip(), suffix
+
+
+PYTHON = PythonProfile()

--- a/src/housestyle/infrastructure/parser.py
+++ b/src/housestyle/infrastructure/parser.py
@@ -1,0 +1,161 @@
+from tree_sitter import Node, Query, QueryCursor
+from tree_sitter_language_pack import get_language, get_parser
+
+from ..domain.comment import (
+    CommentBlock,
+    CommentForm,
+    CommentLine,
+    CommentPlacement,
+    SymbolRef,
+)
+from ..domain.document import Document
+from ..domain.ports import LanguageProfile
+from ..domain.position import SourceRange
+
+
+_DEFINITION_TYPES = frozenset({'function_definition', 'class_definition', 'decorated_definition'})
+
+
+class TreeSitterParser:
+    def __init__(self, profiles: tuple[LanguageProfile, ...]) -> None:
+        self._profiles = {profile.language_id: profile for profile in profiles}
+
+    def supports(self, language_id: str) -> bool:
+        return language_id in self._profiles
+
+    def parse(self, document: Document) -> tuple[CommentBlock, ...]:
+        profile = self._profiles.get(document.language_id)
+        if profile is None:
+            return ()
+        data = document.text.encode('utf-8')
+        tree = get_parser(document.language_id).parse(data)  # pyright: ignore[reportArgumentType]
+        captures = self._capture(profile, document.language_id, tree.root_node)
+        blocks = [self._doc_block(profile, document, node) for node in captures['docstring']]
+        blocks.extend(
+            self._line_block(profile, document, group) for group in self._group_lines(document, captures['comment'])
+        )
+        return tuple(sorted(blocks, key=lambda block: block.range.start))
+
+    def _capture(self, profile: LanguageProfile, language_id: str, root: Node) -> dict[str, list[Node]]:
+        query = Query(get_language(language_id), profile.query())  # pyright: ignore[reportArgumentType]
+        raw = QueryCursor(query).captures(root)
+        found: dict[str, list[Node]] = {'comment': [], 'docstring': []}
+        for name, nodes in raw.items():
+            found.setdefault(name, []).extend(nodes)
+        seen: set[int] = set()
+        for name in found:
+            unique = [node for node in found[name] if not (node.start_byte in seen or seen.add(node.start_byte))]
+            found[name] = sorted(unique, key=lambda node: node.start_byte)
+        return found
+
+    def _group_lines(self, document: Document, nodes: list[Node]) -> list[list[Node]]:
+        groups: list[list[Node]] = []
+        for node in nodes:
+            row = node.start_point[0]
+            if groups and self._continues(document, groups[-1][-1], node, row):
+                groups[-1].append(node)
+            else:
+                groups.append([node])
+        return groups
+
+    def _continues(self, document: Document, previous: Node, node: Node, row: int) -> bool:
+        if previous.start_point[0] != row - 1:
+            return False
+        if self._is_trailing(document, previous) or self._is_trailing(document, node):
+            return False
+        return previous.start_point[1] == node.start_point[1]
+
+    def _is_trailing(self, document: Document, node: Node) -> bool:
+        line = document.positions.line_text(node.start_point[0])
+        return bool(line[: node.start_point[1]].strip())
+
+    def _line_block(self, profile: LanguageProfile, document: Document, nodes: list[Node]) -> CommentBlock:
+        lines = tuple(self._line(profile, document, node, CommentForm.LINE) for node in nodes)
+        placement = self._placement(document, nodes[-1], is_doc=False)
+        return CommentBlock(
+            range=SourceRange(lines[0].range.start, lines[-1].range.end),
+            lines=lines,
+            form=CommentForm.LINE,
+            placement=placement,
+            attachment=self._attachment(profile, nodes[-1], is_doc=False),
+        )
+
+    def _doc_block(self, profile: LanguageProfile, document: Document, node: Node) -> CommentBlock:
+        first_row, last_row = node.start_point[0], node.end_point[0]
+        lines: list[CommentLine] = []
+        for row in range(first_row, last_row + 1):
+            text = document.positions.line_text(row)
+            span = document.positions.line_range(row)
+            indent, marker, payload, suffix = profile.split_marker(text, CommentForm.DOC)
+            lines.append(CommentLine(range=span, indent=indent, marker=marker, payload=payload, suffix=suffix))
+        return CommentBlock(
+            range=SourceRange(lines[0].range.start, lines[-1].range.end),
+            lines=tuple(lines),
+            form=CommentForm.DOC,
+            placement=self._placement(document, node, is_doc=True),
+            attachment=self._attachment(profile, node, is_doc=True),
+        )
+
+    def _line(self, profile: LanguageProfile, document: Document, node: Node, form: CommentForm) -> CommentLine:
+        row, column = node.start_point
+        text = document.positions.line_text(row)
+        prefix = text[:column]
+        indent, marker, payload, suffix = profile.split_marker(text[column:], form)
+        return CommentLine(
+            range=document.positions.line_range(row),
+            indent=prefix + indent,
+            marker=marker,
+            payload=payload,
+            suffix=suffix,
+        )
+
+    def _placement(self, document: Document, node: Node, *, is_doc: bool) -> CommentPlacement:
+        if is_doc:
+            owner = self._owning_definition(node)
+            return CommentPlacement.FILE_HEADER if owner is None else CommentPlacement.LEADING_DECLARATION
+        if self._is_trailing(document, node):
+            return CommentPlacement.TRAILING
+        if self._next_definition(node) is not None:
+            return CommentPlacement.LEADING_DECLARATION
+        if node.parent is not None and node.parent.type == 'module' and not self._has_code_before(node):
+            return CommentPlacement.FILE_HEADER
+        return CommentPlacement.INLINE_BODY
+
+    def _has_code_before(self, node: Node) -> bool:
+        parent = node.parent
+        if parent is None:
+            return False
+        return any(
+            sibling.start_byte < node.start_byte and sibling.type != 'comment' for sibling in parent.named_children
+        )
+
+    def _next_definition(self, node: Node) -> Node | None:
+        candidate = node.next_named_sibling
+        while candidate is not None:
+            if candidate.type in _DEFINITION_TYPES:
+                return candidate
+            if candidate.type != 'comment':
+                return None
+            candidate = candidate.next_named_sibling
+        return None
+
+    def _owning_definition(self, node: Node) -> Node | None:
+        cursor = node.parent
+        while cursor is not None:
+            if cursor.type in _DEFINITION_TYPES:
+                return cursor
+            if cursor.type == 'module':
+                return None
+            cursor = cursor.parent
+        return None
+
+    def _attachment(self, profile: LanguageProfile, node: Node, *, is_doc: bool) -> SymbolRef | None:
+        target = self._owning_definition(node) if is_doc else self._next_definition(node)
+        if target is None:
+            return None
+        named = target.child_by_field_name('name')
+        if named is None or named.text is None:
+            return None
+        name = named.text.decode('utf-8')
+        kind = 'class' if target.type == 'class_definition' else 'function'
+        return SymbolRef(name=name, kind=kind, visibility=profile.visibility_of(name))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,170 @@
+import pytest
+
+from housestyle.domain import CommentBlock, CommentForm, CommentPlacement, Document, Visibility
+from housestyle.infrastructure import DEFAULT_PARSER
+
+
+def parse(source: str) -> tuple[CommentBlock, ...]:
+    return DEFAULT_PARSER.parse(Document(uri='file:///a.py', text=source, language_id='python'))
+
+
+def prose_of(source: str) -> list[str]:
+    return [block.prose().flattened for block in parse(source)]
+
+
+def test_an_unsupported_language_yields_nothing() -> None:
+    assert DEFAULT_PARSER.parse(Document(uri='a.rb', text='# hi', language_id='ruby')) == ()
+    assert DEFAULT_PARSER.supports('python')
+    assert not DEFAULT_PARSER.supports('ruby')
+
+
+def test_a_hash_comment_is_extracted_without_its_marker() -> None:
+    assert prose_of('# a note\n') == ['a note']
+
+
+def test_a_docstring_is_extracted_even_though_it_is_not_a_comment_node() -> None:
+    assert prose_of('def f():\n    """A docstring."""\n') == ['A docstring.']
+
+
+def test_consecutive_hash_lines_group_into_one_block() -> None:
+    blocks = parse('# first line,\n# second line.\nx = 1\n')
+    assert len(blocks) == 1
+    assert blocks[0].line_count == 2
+    assert blocks[0].prose().flattened == 'first line, second line.'
+
+
+def test_a_blank_line_separates_two_blocks() -> None:
+    assert len(parse('# first\n\n# second\nx = 1\n')) == 2
+
+
+def test_differing_indentation_separates_two_blocks() -> None:
+    assert len(parse('def f():\n    # inner\n# outer\n    pass\n')) == 2
+
+
+def test_a_hash_inside_a_string_literal_is_not_a_comment() -> None:
+    assert prose_of('colour = "#ff0000 not a comment"\n') == []
+
+
+def test_a_string_in_expression_position_that_is_not_first_is_not_a_docstring() -> None:
+    assert prose_of('def f():\n    x = 1\n    "not a docstring"\n    return x\n') == []
+
+
+def test_a_bare_string_statement_after_a_docstring_is_not_a_second_docstring() -> None:
+    assert prose_of('def f():\n    """Real."""\n    "decoy"\n') == ['Real.']
+
+
+def test_a_trailing_comment_excludes_the_code_before_it() -> None:
+    blocks = parse('y = x  # trailing note\n')
+    assert blocks[0].prose().flattened == 'trailing note'
+    assert blocks[0].placement is CommentPlacement.TRAILING
+
+
+def test_a_trailing_comment_counts_the_code_in_its_physical_width() -> None:
+    line = parse('y = x  # trailing note\n')[0].lines[0]
+    assert line.indent == 'y = x  '
+    assert line.physical_width == len('y = x  # trailing note')
+
+
+def test_a_trailing_comment_does_not_group_with_a_standalone_one() -> None:
+    assert len(parse('y = x  # trailing\n# standalone\nz = 2\n')) == 2
+
+
+@pytest.mark.parametrize(
+    ('source', 'expected'),
+    [
+        ('"""Module level."""\n', CommentPlacement.FILE_HEADER),
+        ('# header note\nimport os\n', CommentPlacement.FILE_HEADER),
+        ('# leading\ndef f():\n    pass\n', CommentPlacement.LEADING_DECLARATION),
+        ('def f():\n    """Doc."""\n', CommentPlacement.LEADING_DECLARATION),
+        ('def f():\n    # inside\n    pass\n', CommentPlacement.INLINE_BODY),
+        ('x = 1  # trailing\n', CommentPlacement.TRAILING),
+    ],
+)
+def test_placement_classification(source: str, expected: CommentPlacement) -> None:
+    assert parse(source)[0].placement is expected
+
+
+def test_a_comment_after_code_at_module_level_is_not_a_file_header() -> None:
+    assert parse('import os\n\n# not a header\nx = 1\n')[0].placement is CommentPlacement.INLINE_BODY
+
+
+def test_a_comment_separated_from_a_definition_by_a_second_comment_still_attaches() -> None:
+    blocks = parse('# one\n# two\ndef build():\n    pass\n')
+    assert blocks[0].attachment is not None
+    assert blocks[0].attachment.name == 'build'
+
+
+def test_visibility_follows_the_leading_underscore() -> None:
+    public = parse('def build():\n    """Doc."""\n')[0]
+    internal = parse('def _helper():\n    """Doc."""\n')[0]
+
+    assert public.attachment is not None
+    assert internal.attachment is not None
+    assert public.attachment.visibility is Visibility.PUBLIC
+    assert internal.attachment.visibility is Visibility.INTERNAL
+    assert public.attaches_to_public_symbol
+    assert not internal.attaches_to_public_symbol
+
+
+def test_a_class_docstring_attaches_to_the_class() -> None:
+    block = parse('class Widget:\n    """Doc."""\n')[0]
+    assert block.attachment is not None
+    assert block.attachment.kind == 'class'
+    assert block.attachment.name == 'Widget'
+
+
+def test_form_distinguishes_docstrings_from_hash_comments() -> None:
+    assert parse('def f():\n    """Doc."""\n')[0].form is CommentForm.DOC
+    assert parse('# note\n')[0].form is CommentForm.LINE
+
+
+def test_a_multiline_docstring_keeps_every_physical_line() -> None:
+    block = parse('def f():\n    """Summary.\n\n    Detail here.\n    """\n')[0]
+    assert block.line_count == 4
+    assert block.prose().flattened == 'Summary. Detail here.'
+
+
+def test_a_prefixed_docstring_delimiter_is_stripped() -> None:
+    assert prose_of('def f():\n    r"""Raw doc."""\n') == ['Raw doc.']
+
+
+def test_single_quoted_docstrings_are_handled() -> None:
+    assert prose_of("def f():\n    '''Single quoted.'''\n") == ['Single quoted.']
+
+
+def test_physical_width_counts_indent_and_marker() -> None:
+    source = 'def a():\n    def b():\n        def c():\n            # payload\n            pass\n'
+    line = parse(source)[0].lines[0]
+    assert line.payload == 'payload'
+    assert line.physical_width == len('            # payload')
+
+
+@pytest.mark.parametrize(
+    'source',
+    [
+        '"""Module."""\nimport os\n\n\n# lead\n# more\ndef build(x):\n    """Doc.\n\n    Detail.\n    """\n    # inner\n    return x  # trailing\n',
+        'class _Thing:\n    """Doc."""\n\n    def _method(self):\n        # note\n        pass\n',
+        '# only a comment\n',
+    ],
+)
+def test_every_block_range_reproduces_its_rendering(source: str) -> None:
+    data = source.encode('utf-8')
+    for block in parse(source):
+        assert data[block.range.start : block.range.end].decode('utf-8') == block.render()
+
+
+def test_blocks_come_back_in_source_order() -> None:
+    source = '"""Header."""\n# middle\ndef f():\n    """Doc."""\n'
+    starts = [block.range.start for block in parse(source)]
+    assert starts == sorted(starts)
+
+
+def test_the_profile_satisfies_the_language_profile_port() -> None:
+    from housestyle.domain import LanguageProfile, SourceParser
+    from housestyle.infrastructure import PYTHON
+
+    profile: LanguageProfile = PYTHON
+    parser: SourceParser = DEFAULT_PARSER
+    assert profile.language_id == 'python'
+    assert '.py' in profile.extensions
+    assert parser.supports('python')

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,10 @@ wheels = [
 name = "housestyle"
 version = "0.0.1"
 source = { editable = "." }
+dependencies = [
+    { name = "tree-sitter" },
+    { name = "tree-sitter-language-pack" },
+]
 
 [package.optional-dependencies]
 dev = [
@@ -40,6 +44,8 @@ requires-dist = [
     { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.39.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0" },
+    { name = "tree-sitter", specifier = ">=0.26.0" },
+    { name = "tree-sitter-language-pack", specifier = ">=1.15.8" },
 ]
 provides-extras = ["dev"]
 
@@ -134,4 +140,61 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
     { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
     { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/03/5600b84aff2e6c4fe80cfebb4063fe2f50299521befe5f6092ab8c082f4a/tree_sitter-0.26.0.tar.gz", hash = "sha256:b40c219edccc4564530c96f8f1556f6202b37cda964d1cbd7bd2b7e68b40a245", size = 191423, upload-time = "2026-06-30T12:14:27.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/18/78aae7e4b5a36daaebb0276e4b07d084d45298758000787838e89329e11f/tree_sitter-0.26.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1d6fe0e8fb4df77b5ee816228e2c4475a63d8cc1d4d3a7ffd7097b2b87fc3e95", size = 148679, upload-time = "2026-06-30T12:13:52.27Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e4/b371b9553b0e47d130fc2073e56cab94fecc868be04666bf5bbd1fcd1cc9/tree_sitter-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:514a9bf8993e5210e7970736aaf6020d1759b670e195ef17b1c48f586aa30736", size = 140759, upload-time = "2026-06-30T12:13:53.221Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7d/266fb0f2c41e6fb00b0f40e7a3338cdf99651e6a6511ca72bc78fc697636/tree_sitter-0.26.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10f0d4eb94aa7242dcb7f554bcd24dd7ba1c114f00d58759ba08c7a46c8ec51a", size = 637206, upload-time = "2026-06-30T12:13:54.334Z" },
+    { url = "https://files.pythonhosted.org/packages/40/9f/47cf22febb47132d5b3a507a27bb99ef89fe5c8ec420a13c6daa9b64f782/tree_sitter-0.26.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:335294ce0504fcefde5245dff596778ffaf820205b98ae0b549c72e48855f1d8", size = 664758, upload-time = "2026-06-30T12:13:55.42Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4d/8d144ca3beb46a62a5102b6deac76bb0da55235c2c7840faf3b12f2e9d97/tree_sitter-0.26.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9997ba61368c48ed54e715676afadf703947a1542464e39d047764fb3624b01", size = 647438, upload-time = "2026-06-30T12:13:56.523Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/ed/ed1d6e78520c4fb64ed52fec3f2947bf8c1fbad7bc24e282c56193c9ba42/tree_sitter-0.26.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c56581ad256c4195a21bfe449fed5d44a02fe83a4a7d6e70e6ec302c881191c7", size = 661944, upload-time = "2026-06-30T12:13:57.82Z" },
+    { url = "https://files.pythonhosted.org/packages/10/83/45f5bd43db1b8248d2fd08ef6cbe43e2725c539e09a2cfb8bc2818646788/tree_sitter-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:0f8793fd18ad7eec276ed4b51c097b4bf2002b357259b66b0d75db1f3f41c754", size = 129496, upload-time = "2026-06-30T12:13:59.216Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8d/be68e6c04563eb54145424cc83fe0aa8b0ba6c90d8989cf8a032671b5f16/tree_sitter-0.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:dea4b4e27d49e9ec5b785d4f994da000e6726882fcc6ad05ec98478500c71aef", size = 116484, upload-time = "2026-06-30T12:14:00.147Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ca/565702c44815393e3a973552ad546db4e5ca081ca8698640b4e93d809f51/tree_sitter-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6cb2bd20efb2544c19ac54486ab7cb8ec7b36f913bbe1ce95df84acb96743d9c", size = 148934, upload-time = "2026-06-30T12:14:01.188Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6f/8bb61957f16ec1b1d92410a006cdc84a952b6352a7313b2ad299f2d21484/tree_sitter-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:918d89529786873f0982a0f59c2a303cd065fbfd1b903d71a8e4e1584f67b42e", size = 140820, upload-time = "2026-06-30T12:14:02.087Z" },
+    { url = "https://files.pythonhosted.org/packages/78/0a/8a6f08559182643a814a4ab559948ae817b2851890fd9b995a4fff6541ce/tree_sitter-0.26.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30a88be89ff1f2755297f81e8080d88b795dd98720c3f9fa2acf93873182cc95", size = 638844, upload-time = "2026-06-30T12:14:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2f/6e6781b31677231366cb3cf27bc8269157f6d4b03c9032865a4f5f2bbe7e/tree_sitter-0.26.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a6b333b0282d8bb0af741f9b018bd2523d4eecb2686bf6717066a625fecfaa4", size = 667487, upload-time = "2026-06-30T12:14:04.669Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0b/0483078c8567445557a7015b0e5b187f6d7d4fda73464df9c4bdea7f7f3c/tree_sitter-0.26.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3f3c44339dd34fe8eb2b8d5aa7610660499a795f70376b130bbee7a437337280", size = 647975, upload-time = "2026-06-30T12:14:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/27/68/da83ca72c984e96ab4eb3bee0db1a6ffb5de1c8c455f92bd9f420cde7f0e/tree_sitter-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:94550e13b6ae576969da40246f4c4abb206380b5375ad43f26dd9151d55438e3", size = 665018, upload-time = "2026-06-30T12:14:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/36/4d67927fd47b89af4a00f65f55a7370e28778cd50e972c2430487e3ecc27/tree_sitter-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:ca89e361a276dbc934b28a43dd881199e25d34ff5493ee0ce45f3c52a6124a37", size = 129619, upload-time = "2026-06-30T12:14:08.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/72/cdefad523eb78710679c6da6a79e3d90f5afd32b1c6aa5a17bac7eef99f6/tree_sitter-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:bc6cb01d5ee75c85424aa1f1c72a82d8f07fd52539a0f3c4a6ed3e8721079b84", size = 116545, upload-time = "2026-06-30T12:14:09.273Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b0/465257cf8f972ad9f9812ec1cbaa8ec210ebebb601ade9a15881aa2436b4/tree_sitter-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ed0889dbed843ce45ede9f5169c0b2dea2222f12685844a03fadb81f12705867", size = 148893, upload-time = "2026-06-30T12:14:10.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/19d093e854b45e807fecfdd26105c266f43aeecc39c4dc97992a7074ad5a/tree_sitter-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6189c6c340c7384357711e3d92645e96bfb79f7a502f86de1ebdb23eb43f7dab", size = 140829, upload-time = "2026-06-30T12:14:11.626Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ee/87e74671ed63a837e7a1f17ab94aa3913871e033b27523d8e7b83d6f7ad0/tree_sitter-0.26.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ff2e0750b7daa722302838356d7b65e303829b7eb73c915df127ddba115e1d1", size = 639334, upload-time = "2026-06-30T12:14:12.836Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e7/f7e04cd9dff6b6ac0adf23922796fbc76accd4cf4bcda50542748d485679/tree_sitter-0.26.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7075ef857ef86f327dbb72d1e2574dda78db5754b3a1fca6506acd7fe5d561a7", size = 668102, upload-time = "2026-06-30T12:14:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/90/0bfb16b7894fea728c774a89d5af421a9368a2f913bbd4e8dcab7caaecfb/tree_sitter-0.26.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:26c996c1edfee86e977bb3f5462e74fcec0d0b0db1e85a3c475875763caa03be", size = 648560, upload-time = "2026-06-30T12:14:15.302Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e6/0fe05ba396e9623b0ae40ccf34171336b8701ec8d7bd0ee9f5224d638665/tree_sitter-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00289bfe7978f3e0dc0ce69813a20fa9f44ea4c100b3ec62043e5eb74ccfc3a2", size = 665121, upload-time = "2026-06-30T12:14:16.403Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/a944b1ca35bed6068dc84a9967aaf3049d8cc0b7a36179eea8787270a6ab/tree_sitter-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:93e220cab7e6a823efeb2046c49171427de92ef71c7c681c01820d14d8d3721f", size = 129615, upload-time = "2026-06-30T12:14:17.463Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ef/c7ca48293580d2249f36940c4eed5b4ddeb9ce75baf9a4ef30621987e0c7/tree_sitter-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:b31a8195d2f224224c530ac814632d98c1dcc123d227442c07c736e86b70d564", size = 116525, upload-time = "2026-06-30T12:14:18.53Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/7a/4d84e6f6ae2c3e757490dd84de251712c31e293dfe31f28da1ec019cefa2/tree_sitter-0.26.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5a3c93a352b7e6f70f73e121bbfa2d0117ba7478bd51114ed35c91b0b78814fa", size = 148901, upload-time = "2026-06-30T12:14:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d9/efe62ec65dc9d096e834d27b8c058127e2146e42ff3380b822a233f016a6/tree_sitter-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5fc2f41bf246ff2f70a9cc3690be35ec7580a4923151873d898c8bcb1a4503d3", size = 140805, upload-time = "2026-06-30T12:14:20.478Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2c/c82326b7b97e3c485c18679883b16f89e5e913c639d3b219d3da70c9e67e/tree_sitter-0.26.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8ea92a255c91671a7ec4625aba3ab7bb5220c423630ffbf83c45d7312abe084", size = 640586, upload-time = "2026-06-30T12:14:21.527Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/7a/f56e7d8282859452611024c7cbc623bfba5b24b8cb9b8f8bc88c5219fe9a/tree_sitter-0.26.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f665510f0fcf4636fb9696f1f7853bed7a3bd764b7bb0cb8494e619c14ed5a0c", size = 668300, upload-time = "2026-06-30T12:14:22.728Z" },
+    { url = "https://files.pythonhosted.org/packages/91/51/240ee81b9d5e9ca0a6cb1528e8605ffa70ab58c89ce126631be96d3e4bae/tree_sitter-0.26.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:253df7ab82cc0a9d311cd65f06e9f99fb3eac55996ae9fc94da22f123a861b90", size = 649627, upload-time = "2026-06-30T12:14:23.819Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/54/760035cefedf9eb44f0f84c4ac22f1322e73155853e272576ee876336312/tree_sitter-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ff80d4833d330a73184a3ac5132abe93c575d2dea31975c6f15c0d21fef238aa", size = 664885, upload-time = "2026-06-30T12:14:25.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1b/0b36fe2a984ecedc4ce6aefd5d56447a6626a8e9b595c4e48658510ce8f8/tree_sitter-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:a4033fecc8f606c7f2e8b8014d0057b74668a7f0152763606f7bc25c5f9ec64c", size = 132688, upload-time = "2026-06-30T12:14:26.106Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/74/ebc041a13fbf40144afdb0d4b447e48e0b4012ca866c63de8b48f801f0c1/tree_sitter-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:823251c4b6725a7c03ed497a339135ede7ae4bdde75bb8be7ef5e305aeb4ff52", size = 120287, upload-time = "2026-06-30T12:14:26.991Z" },
+]
+
+[[package]]
+name = "tree-sitter-language-pack"
+version = "1.15.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tree-sitter" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/e8/d7f9df7cfb1d297a59033b2d357f0566a24af97b6fd079cbfa803ab28c2b/tree_sitter_language_pack-1.15.8.tar.gz", hash = "sha256:eb42ba020af2433165fe28fce3681ff63b6d449a689f84bb458d15d802bfb414", size = 87342, upload-time = "2026-08-23T23:29:20.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/c2/f8794f06b6fffcc4956620697f56bc25c7f1e1d6746696a9ad3c116caa9e/tree_sitter_language_pack-1.15.8-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dc4f930db94ecc4eb310696540f7136bfa798ce4b9b40df32a2c024b0a473ac6", size = 2250160, upload-time = "2026-08-23T23:29:11.061Z" },
+    { url = "https://files.pythonhosted.org/packages/64/72/97c1f45805182e8725e98266197929bb6efc9f973c0952711848ba170702/tree_sitter_language_pack-1.15.8-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ab553907acbe59efbf541ad15524329b92dd3474492d44b76be007df63178c09", size = 2138655, upload-time = "2026-08-23T23:29:13.568Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/68/046b12788896f771349b57b75f029527bc9e06548aa9079f8acc1c7f31a5/tree_sitter_language_pack-1.15.8-cp310-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:d8f700e9a71e53a266ca2d8b7be76a95e4fdffc1621e9c94c654590106d66453", size = 2298886, upload-time = "2026-08-23T23:29:14.84Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/24/590433c52bb191387aab2c260da739bdafc973eded5cdfcc52dadb39d229/tree_sitter_language_pack-1.15.8-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:31a7a356db54da802d8764d2c403a78ce56e4c476013f9a10173551a6a6cd3b4", size = 2412854, upload-time = "2026-08-23T23:29:16.297Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ae/fb4bdb06789bd53cc8a4d94e515a4017b40b1f4ab55d218827dca51dee08/tree_sitter_language_pack-1.15.8-cp310-abi3-win_amd64.whl", hash = "sha256:9995f0ab996e3c3369d6291d480e9530da87d4f40c76917812f1f01395a37def", size = 2192422, upload-time = "2026-08-23T23:29:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/b2/50ceca2598f672953da8976bb92129b39798a4e1bf8244558a0d163a2b0f/tree_sitter_language_pack-1.15.8-cp310-abi3-win_arm64.whl", hash = "sha256:be2780574d4ab34507c17dbfb858841bc45c96b998e536150df53f52767fd5e1", size = 2094854, upload-time = "2026-08-23T23:29:19.135Z" },
 ]


### PR DESCRIPTION
First working extraction. Python lands before TypeScript on purpose.

## Why Python first

Tree-sitter models the two languages differently, verified rather than assumed:

```
TypeScript                     Python
comment  /** doc */            block
comment  // line                 string   """docstring"""   <- not a comment node
comment  /* block */             comment  # line
```

TypeScript exposes all three forms as `comment` nodes, so one query covers it. Python exposes `#` comments as comment nodes while a docstring is a `string` inside a `block`. Building the simple case first risked a `SourceParser` shaped around "comments are comment nodes", with the gap surfacing only at the second language.

It also brings self-hosting forward, since this repo is the corpus.

## The invariant that matters

`block.range` is line aligned, not node aligned, so the source it covers always reproduces `block.render()`. Node alignment looked right until a trailing comment showed the problem: its rendering carries the code to its left as indent, so applying it as an edit over the node range would duplicate that code.

Pinned by test, and verified across all 216 blocks in the openapi-mcp-gateway corpus with zero mismatches.

## A query that over-matched

`(module . (expression_statement (string)))` captured `colour = "#ff0000"` as a docstring. This grammar has no `expression_statement` wrapper, so the direct-child patterns are the ones doing real work and the wrapper patterns only added false positives. Caught by the acceptance test rather than by reading.

153 tests.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)