### PR TITLE
Measure the corpus instead of guessing thresholds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
     "tree-sitter>=0.26.0",
     "tree-sitter-language-pack>=1.15.8",
+    "typer>=0.27.1",
 ]
 
 [project.optional-dependencies]

--- a/src/housestyle/application/__init__.py
+++ b/src/housestyle/application/__init__.py
@@ -1,0 +1,4 @@
+from .statistics import CorpusStatistics, Distribution, MeasureCorpus
+
+
+__all__ = ['CorpusStatistics', 'Distribution', 'MeasureCorpus']

--- a/src/housestyle/application/statistics.py
+++ b/src/housestyle/application/statistics.py
@@ -1,0 +1,91 @@
+import dataclasses
+import statistics
+
+from ..domain.comment import CommentBlock, CommentForm, CommentPlacement, Visibility
+from ..domain.document import Document
+from ..domain.ports import SourceParser
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Distribution:
+    label: str
+    values: tuple[int, ...]
+
+    @property
+    def count(self) -> int:
+        return len(self.values)
+
+    def percentile(self, fraction: float) -> int:
+        if not self.values:
+            return 0
+        ordered = sorted(self.values)
+        index = min(len(ordered) - 1, max(0, round(fraction * (len(ordered) - 1))))
+        return ordered[index]
+
+    @property
+    def maximum(self) -> int:
+        return max(self.values, default=0)
+
+    @property
+    def median(self) -> int:
+        return round(statistics.median(self.values)) if self.values else 0
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CorpusStatistics:
+    documents: int
+    blocks: int
+    line_counts: tuple[Distribution, ...]
+    physical_widths: Distribution
+    sentence_lengths: Distribution
+    unbreakable_at: tuple[tuple[int, int], ...]
+
+    def line_counts_for(self, label: str) -> Distribution:
+        for distribution in self.line_counts:
+            if distribution.label == label:
+                return distribution
+        return Distribution(label, ())
+
+
+class MeasureCorpus:
+    def __init__(self, parser: SourceParser, widths: tuple[int, ...] = (72, 80, 88, 100, 120)) -> None:
+        self._parser = parser
+        self._widths = widths
+
+    def run(self, documents: tuple[Document, ...]) -> CorpusStatistics:
+        grouped: dict[str, list[int]] = {}
+        widths: list[int] = []
+        lengths: list[int] = []
+        unbreakable = dict.fromkeys(self._widths, 0)
+        blocks = 0
+
+        for document in documents:
+            for block in self._parser.parse(document):
+                blocks += 1
+                grouped.setdefault(self._label(block), []).append(block.line_count)
+                widths.extend(line.physical_width for line in block.lines)
+                for sentence in block.prose().sentences():
+                    lengths.append(len(sentence.text))
+                    for width in self._widths:
+                        if self._is_unbreakable(sentence.text, width):
+                            unbreakable[width] += 1
+
+        return CorpusStatistics(
+            documents=len(documents),
+            blocks=blocks,
+            line_counts=tuple(Distribution(label, tuple(values)) for label, values in sorted(grouped.items())),
+            physical_widths=Distribution('physical-width', tuple(widths)),
+            sentence_lengths=Distribution('sentence-length', tuple(lengths)),
+            unbreakable_at=tuple(sorted(unbreakable.items())),
+        )
+
+    def _label(self, block: CommentBlock) -> str:
+        if block.form is CommentForm.DOC:
+            visibility = Visibility.PUBLIC if block.attaches_to_public_symbol else Visibility.INTERNAL
+            return f'doc/{visibility.value}'
+        if block.placement is CommentPlacement.FILE_HEADER:
+            return 'line/file-header'
+        return f'line/{block.placement.value}'
+
+    def _is_unbreakable(self, sentence: str, width: int) -> bool:
+        return len(sentence) > width and ',' not in sentence

--- a/src/housestyle/presentation/cli.py
+++ b/src/housestyle/presentation/cli.py
@@ -1,9 +1,85 @@
+import pathlib
 import sys
 
+import typer
+
 from .. import __version__
+from ..application import CorpusStatistics, MeasureCorpus
+from ..domain.document import Document
+from ..infrastructure import DEFAULT_PARSER, PYTHON
+
+
+app = typer.Typer(add_completion=False, help='A linter and formatter for the prose inside code comments.')
+
+PERCENTILES = (0.5, 0.75, 0.9, 0.95, 0.99)
+
+
+def _load(paths: tuple[pathlib.Path, ...]) -> tuple[Document, ...]:
+    files: list[pathlib.Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(sorted(candidate for candidate in path.rglob('*') if candidate.suffix in PYTHON.extensions))
+        elif path.suffix in PYTHON.extensions:
+            files.append(path)
+    documents: list[Document] = []
+    for file in files:
+        try:
+            text = file.read_text(encoding='utf-8')
+        except (OSError, UnicodeDecodeError):
+            continue
+        documents.append(Document(uri=file.resolve().as_uri(), text=text, language_id=PYTHON.language_id))
+    return tuple(documents)
+
+
+def _render(report: CorpusStatistics) -> str:
+    header = f'{report.documents} documents, {report.blocks} comment blocks'
+    lines = [
+        header,
+        '',
+        'block line counts',
+        f'{"group":24s} {"n":>6s} {"med":>5s} ' + ' '.join(f'p{int(p * 100):<3d}' for p in PERCENTILES) + '  max',
+    ]
+    for distribution in report.line_counts:
+        cells = ' '.join(f'{distribution.percentile(p):<4d}' for p in PERCENTILES)
+        lines.append(
+            f'{distribution.label:24s} {distribution.count:6d} {distribution.median:5d} {cells} {distribution.maximum:4d}'
+        )
+
+    for distribution in (report.physical_widths, report.sentence_lengths):
+        cells = ' '.join(f'{distribution.percentile(p):<4d}' for p in PERCENTILES)
+        lines.extend(
+            [
+                '',
+                distribution.label,
+                f'{"":24s} {distribution.count:6d} {distribution.median:5d} {cells} {distribution.maximum:4d}',
+            ]
+        )
+
+    lines.extend(['', 'sentences over width with no comma to break at'])
+    for width, count in report.unbreakable_at:
+        share = count / report.sentence_lengths.count * 100 if report.sentence_lengths.count else 0.0
+        lines.append(f'  width {width:3d}  {count:5d} sentences  {share:5.2f}%')
+    return '\n'.join(lines)
+
+
+@app.command()
+def stats(paths: list[pathlib.Path] = typer.Argument(..., help='Files or directories to measure.')) -> None:
+    documents = _load(tuple(paths))
+    if not documents:
+        typer.echo('No readable source files found.', err=True)
+        raise typer.Exit(1)
+    typer.echo(_render(MeasureCorpus(DEFAULT_PARSER).run(documents)))
+
+
+@app.command()
+def version() -> None:
+    typer.echo(f'housestyle {__version__}')
 
 
 def main() -> int:
-    sys.stdout.write(f'housestyle {__version__}\n')
-    sys.stdout.write('Not implemented yet. See the repository for status.\n')
+    app()
     return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,34 @@
+import pathlib
+
 import pytest
 
-from housestyle import __version__
-from housestyle.presentation.cli import main
+from housestyle.presentation.cli import app
 
 
-def test_main_succeeds(capsys: pytest.CaptureFixture[str]) -> None:
-    assert main() == 0
+def test_version_prints_the_package_version(capsys: pytest.CaptureFixture[str]) -> None:
+    from housestyle import __version__
+
+    with pytest.raises(SystemExit) as exit_info:
+        app(['version'])
+    assert exit_info.value.code == 0
     assert __version__ in capsys.readouterr().out
+
+
+def test_stats_reports_a_measured_corpus(tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    source = tmp_path / 'sample.py'
+    source.write_text('def build():\n    """Public doc."""\n    # inline note\n', encoding='utf-8')
+
+    with pytest.raises(SystemExit) as exit_info:
+        app(['stats', str(source)])
+    assert exit_info.value.code == 0
+
+    output = capsys.readouterr().out
+    assert '1 documents, 2 comment blocks' in output
+    assert 'doc/public' in output
+    assert 'line/inline-body' in output
+
+
+def test_stats_exits_non_zero_when_nothing_is_readable(tmp_path: pathlib.Path) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        app(['stats', str(tmp_path)])
+    assert exit_info.value.code == 1

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,78 @@
+import pytest
+
+from housestyle.application import Distribution, MeasureCorpus
+from housestyle.domain import Document
+from housestyle.infrastructure import DEFAULT_PARSER
+
+
+def measure(*sources: str):
+    documents = tuple(
+        Document(uri=f'file:///a{index}.py', text=source, language_id='python') for index, source in enumerate(sources)
+    )
+    return MeasureCorpus(DEFAULT_PARSER).run(documents)
+
+
+def test_an_empty_corpus_reports_nothing() -> None:
+    report = measure()
+    assert report.documents == 0
+    assert report.blocks == 0
+    assert report.physical_widths.count == 0
+
+
+def test_percentiles_on_an_empty_distribution_are_zero() -> None:
+    empty = Distribution('none', ())
+    assert empty.percentile(0.9) == 0
+    assert empty.maximum == 0
+    assert empty.median == 0
+
+
+def test_percentiles_bracket_the_data() -> None:
+    distribution = Distribution('d', tuple(range(1, 101)))
+    assert distribution.percentile(0.0) == 1
+    assert distribution.percentile(1.0) == 100
+    assert distribution.median == 50
+    assert distribution.percentile(0.5) <= distribution.percentile(0.9) <= distribution.maximum
+
+
+def test_blocks_group_by_form_placement_and_visibility() -> None:
+    report = measure(
+        'def build():\n    """Public doc."""\n',
+        'def _helper():\n    """Internal doc."""\n',
+        'def f():\n    # inline\n    pass\n',
+        'x = 1  # trailing\n',
+    )
+    labels = {distribution.label for distribution in report.line_counts}
+    assert labels == {'doc/public', 'doc/internal', 'line/inline-body', 'line/trailing'}
+    assert report.line_counts_for('doc/public').count == 1
+    assert report.line_counts_for('missing').count == 0
+
+
+def test_physical_width_measures_the_source_line_not_the_payload() -> None:
+    indent = ' ' * 40
+    report = measure(f'def a():\n{indent}# short\n')
+    assert report.physical_widths.maximum == len(f'{indent}# short')
+
+
+def test_an_unbreakable_sentence_is_one_that_is_long_with_no_comma() -> None:
+    breakable = 'x = 1  # ' + 'word ' * 30 + 'and, a comma here.\n'
+    unbreakable = 'y = 2  # ' + 'word ' * 30 + 'no comma at all.\n'
+    report = measure(breakable, unbreakable)
+    counts = dict(report.unbreakable_at)
+    assert counts[80] == 1
+    assert counts[120] == 1
+
+
+def test_a_short_sentence_is_never_unbreakable() -> None:
+    report = measure('# brief note.\n')
+    assert all(count == 0 for _, count in report.unbreakable_at)
+
+
+@pytest.mark.parametrize('width', [72, 80, 88, 100, 120])
+def test_every_configured_width_is_reported(width: int) -> None:
+    assert width in dict(measure('# note.\n').unbreakable_at)
+
+
+def test_unbreakable_counts_fall_as_the_width_rises() -> None:
+    source = '# ' + 'word ' * 20 + 'without any comma.\n'
+    counts = [count for _, count in sorted(measure(source).unbreakable_at)]
+    assert counts == sorted(counts, reverse=True)

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
 name = "basedpyright"
 version = "1.39.10"
 source = { registry = "https://pypi.org/simple" }
@@ -30,6 +39,7 @@ source = { editable = "." }
 dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-language-pack" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -46,6 +56,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0" },
     { name = "tree-sitter", specifier = ">=0.26.0" },
     { name = "tree-sitter-language-pack", specifier = ">=1.15.8" },
+    { name = "typer", specifier = ">=0.27.1" },
 ]
 provides-extras = ["dev"]
 
@@ -56,6 +67,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -118,6 +150,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.16.4"
 source = { registry = "https://pypi.org/simple" }
@@ -140,6 +185,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
     { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
     { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -197,4 +251,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/24/590433c52bb191387aab2c260da739bdafc973eded5cdfcc52dadb39d229/tree_sitter_language_pack-1.15.8-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:31a7a356db54da802d8764d2c403a78ce56e4c476013f9a10173551a6a6cd3b4", size = 2412854, upload-time = "2026-08-23T23:29:16.297Z" },
     { url = "https://files.pythonhosted.org/packages/3f/ae/fb4bdb06789bd53cc8a4d94e515a4017b40b1f4ab55d218827dca51dee08/tree_sitter_language_pack-1.15.8-cp310-abi3-win_amd64.whl", hash = "sha256:9995f0ab996e3c3369d6291d480e9530da87d4f40c76917812f1f01395a37def", size = 2192422, upload-time = "2026-08-23T23:29:17.707Z" },
     { url = "https://files.pythonhosted.org/packages/bb/b2/50ceca2598f672953da8976bb92129b39798a4e1bf8244558a0d163a2b0f/tree_sitter_language_pack-1.15.8-cp310-abi3-win_arm64.whl", hash = "sha256:be2780574d4ab34507c17dbfb858841bc45c96b998e536150df53f52767fd5e1", size = 2094854, upload-time = "2026-08-23T23:29:19.135Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
 ]


### PR DESCRIPTION
`housestyle stats` exists so the layout thresholds come from data. The first run already contradicted two of my guesses.

## What it reports

```
50 documents, 218 comment blocks

block line counts
group                         n   med p50  p75  p90  p95  p99   max
doc/internal                 56     5 5    6    7    8    13     14
doc/public                  128     4 4    6    7    12   17     38
line/inline-body             28     1 1    2    3    3    4       4

physical-width               801    69 69   89   102  107  116   124
sentence-length              444    81 81   104  155  177  249  1110

sentences over width with no comma to break at
  width  72    112 sentences  25.23%
  width  80     73 sentences  16.44%
  width 100     17 sentences   3.83%
  width 120      5 sentences   1.13%
```

## Two guesses the data killed

**`block-too-long` for internal symbols.** I had guessed three lines, reasoning from the convention's "terse, one line where possible". That line is about `#` comments, and those do behave: `line/inline-body` has a median of 1 and a maximum of 4. Internal **docstrings** are a different population, median 5 and p95 8. A threshold of three would have flagged more than half of them.

**Width 80 for Python.** Under policy B a sentence over width with no comma has no legal break point, so it becomes a `REWRITE` and reaches the agent. At width 80 that is 16.44% of all sentences, 73 messages on this corpus alone, which is exactly the attention spend the design exists to avoid. At 100 it is 3.83%. braid's 80 was set for TypeScript `//` comments; Python docstrings are prose and run longer.

## A finding that needs its own issue

The longest measured sentence is 1,110 characters, and it is not prose. It is a CLI help block of shell examples separated by `\b` markers, which the gateway convention explicitly permits inside a docstring. `Prose` currently treats it as one enormous sentence, and reflow would destroy it. Filed separately.

181 tests.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)