### PR TITLE
Keep literal blocks out of prose

### DIFF
--- a/src/housestyle/domain/comment.py
+++ b/src/housestyle/domain/comment.py
@@ -88,7 +88,13 @@ class CommentBlock:
         return self.attachment is not None and self.attachment.visibility is Visibility.PUBLIC
 
     def prose(self) -> Prose:
-        return Prose('\n'.join(line.payload.strip() for line in self.lines))
+        filled = [line for line in self.lines if line.payload.strip()]
+        base = min((len(line.indent) for line in filled), default=0)
+        rendered = [
+            ' ' * max(0, len(line.indent) - base) + line.payload.rstrip() if line.payload.strip() else ''
+            for line in self.lines
+        ]
+        return Prose('\n'.join(rendered))
 
     def with_payloads(self, payloads: tuple[str, ...]) -> 'CommentBlock':
         if not payloads:

--- a/src/housestyle/domain/prose.py
+++ b/src/housestyle/domain/prose.py
@@ -23,6 +23,8 @@ _SENTENCE_END = re.compile(r'[.!?]')
 _TRAILING_WORD = re.compile(r'([A-Za-z][A-Za-z.]*)$')
 _URL = re.compile(r'\b(?:https?://|www\.)\S+')
 _CODE_SPAN = re.compile(r'`[^`]*`')
+_FENCE = re.compile(r'^\s*(```|~~~)')
+_LITERAL_MARKER = '\\b'
 
 
 class BreakStrength(enum.IntEnum):
@@ -47,6 +49,16 @@ class Sentence:
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
+class Segment:
+    lines: tuple[str, ...]
+    is_literal: bool
+
+    @property
+    def text(self) -> str:
+        return '\n'.join(self.lines)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
 class Prose:
     text: str
 
@@ -54,9 +66,56 @@ class Prose:
     def physical_lines(self) -> tuple[str, ...]:
         return tuple(self.text.split('\n'))
 
+    def segments(self) -> tuple[Segment, ...]:
+        found: list[Segment] = []
+        current: list[str] = []
+        literal = False
+        fenced = False
+        held = False
+
+        def flush(next_literal: bool) -> None:
+            nonlocal current, literal
+            if current and next_literal != literal:
+                found.append(Segment(tuple(current), literal))
+                current = []
+            literal = next_literal
+
+        for line in self.physical_lines:
+            stripped = line.strip()
+            if _FENCE.match(line):
+                fenced = not fenced
+                flush(next_literal=True)
+                current.append(line)
+                continue
+            if stripped.startswith(_LITERAL_MARKER):
+                held = stripped == _LITERAL_MARKER
+                flush(next_literal=True)
+                current.append(line)
+                continue
+            if not stripped:
+                held = False
+                flush(next_literal=fenced)
+                current.append(line)
+                continue
+            flush(next_literal=fenced or held or self._is_indented(line))
+            current.append(line)
+
+        if current:
+            found.append(Segment(tuple(current), literal))
+        return tuple(found)
+
+    def _is_indented(self, line: str) -> bool:
+        return line.startswith(('    ', '\t'))
+
     @property
     def flattened(self) -> str:
-        return ' '.join(line.strip() for line in self.physical_lines if line.strip())
+        return ' '.join(
+            line.strip()
+            for segment in self.segments()
+            if not segment.is_literal
+            for line in segment.lines
+            if line.strip()
+        )
 
     def sentences(self) -> tuple[Sentence, ...]:
         text = self.flattened

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -103,3 +103,31 @@ def test_as_edit_targets_the_block_range() -> None:
     edit = subject.as_edit()
     assert edit.range == SourceRange(4, 40)
     assert edit.new_text == '  // alpha'
+
+
+def test_prose_preserves_indentation_relative_to_the_block() -> None:
+    lines = (
+        CommentLine(SourceRange(0, 1), '    ', '', 'Summary.'),
+        CommentLine(SourceRange(1, 2), '', '', ''),
+        CommentLine(SourceRange(2, 3), '        ', '', 'indented_code()'),
+        CommentLine(SourceRange(3, 4), '    ', '', 'Trailing.'),
+    )
+    block = CommentBlock(
+        range=SourceRange(0, 4),
+        lines=lines,
+        form=CommentForm.DOC,
+        placement=CommentPlacement.LEADING_DECLARATION,
+    )
+    assert block.prose().physical_lines == ('Summary.', '', '    indented_code()', 'Trailing.')
+    assert block.prose().flattened == 'Summary. Trailing.'
+
+
+def test_prose_keeps_uniformly_indented_lines_flush() -> None:
+    lines = tuple(CommentLine(SourceRange(i, i + 1), '        ', '# ', text) for i, text in enumerate(('one', 'two')))
+    block = CommentBlock(
+        range=SourceRange(0, 2),
+        lines=lines,
+        form=CommentForm.LINE,
+        placement=CommentPlacement.INLINE_BODY,
+    )
+    assert block.prose().physical_lines == ('one', 'two')

--- a/tests/test_prose.py
+++ b/tests/test_prose.py
@@ -119,3 +119,45 @@ def test_physical_lines_are_preserved_separately() -> None:
     prose = Prose('one\ntwo\nthree')
     assert prose.physical_lines == ('one', 'two', 'three')
     assert prose.flattened == 'one two three'
+
+
+def test_a_backslash_b_block_is_literal_and_excluded_from_prose() -> None:
+    prose = Prose('Run it.\n\n\\b example --flag value\n\\b example --other value\n\nDone.')
+    literal = [segment for segment in prose.segments() if segment.is_literal]
+
+    assert len(literal) == 1
+    assert literal[0].lines == ('\\b example --flag value', '\\b example --other value')
+    assert prose.flattened == 'Run it. Done.'
+
+
+def test_an_indented_block_is_literal() -> None:
+    prose = Prose('Summary.\n\n    code_line(1)\n    code_line(2)\n\nTrailing text.')
+    assert prose.flattened == 'Summary. Trailing text.'
+
+
+def test_a_fenced_block_is_literal_including_its_fences() -> None:
+    prose = Prose('Before.\n```\ncode here\n```\nAfter.')
+    assert prose.flattened == 'Before. After.'
+
+
+def test_literal_lines_stay_available_for_rendering() -> None:
+    prose = Prose('Before.\n    indented code\nAfter.')
+    assert [segment.lines for segment in prose.segments()] == [
+        ('Before.',),
+        ('    indented code',),
+        ('After.',),
+    ]
+
+
+def test_a_literal_block_produces_no_sentences() -> None:
+    assert Prose('\\b just --an example\n').sentences() == ()
+
+
+def test_a_literal_block_produces_no_break_candidates() -> None:
+    assert Prose('\\b example --a, --b, --c\n').break_candidates() == ()
+
+
+def test_prose_without_literal_blocks_is_unchanged() -> None:
+    prose = Prose('cap the size to the limit,\nan unbounded value faults')
+    assert [segment.is_literal for segment in prose.segments()] == [False]
+    assert prose.flattened == 'cap the size to the limit, an unbounded value faults'


### PR DESCRIPTION
Reflow cannot ship until it is safe on real docstrings, and measurement showed it was not.

## The problem

The longest sentence in the corpus was 1,110 characters and was not prose. It was a CLI help block of shell examples, which the gateway convention explicitly permits inside a docstring. Reflow under policy B would have rewrapped it and destroyed the examples, which is worse than any rule it might enforce.

## Two bugs, not one

**`\b` marks the paragraph that follows.** Click and Typer use a lone `\b` on its own line to suppress rewrapping for the next paragraph. My first attempt treated it as a per-line prefix, which is a form that also appears, so both are handled now.

**`CommentBlock.prose()` was stripping every payload**, destroying the indentation that marks a code block in the first place. Indentation is now preserved relative to the block, so a uniformly indented run of `#` comments still comes back flush while a doubly indented code line inside a docstring keeps its offset.

## Result

Literal lines stay available for rendering but contribute no sentences and no break candidates.

| | before | after |
| --- | --- | --- |
| longest sentence | 1,110 | 310 |
| unbreakable at width 120 | 1.13% | 0.90% |

188 tests.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)