### PR TITLE
Add the rule engine and the lint use case

### DIFF
--- a/src/housestyle/application/__init__.py
+++ b/src/housestyle/application/__init__.py
@@ -1,4 +1,5 @@
+from .linting import LintDocument, RuleEngine
 from .statistics import CorpusStatistics, Distribution, MeasureCorpus
 
 
-__all__ = ['CorpusStatistics', 'Distribution', 'MeasureCorpus']
+__all__ = ['CorpusStatistics', 'Distribution', 'LintDocument', 'MeasureCorpus', 'RuleEngine']

--- a/src/housestyle/application/linting.py
+++ b/src/housestyle/application/linting.py
@@ -1,0 +1,58 @@
+import dataclasses
+
+from ..domain.comment import CommentBlock
+from ..domain.diagnostic import Diagnostic, Report
+from ..domain.document import Document
+from ..domain.ports import SourceParser
+from ..domain.rules import Rule, RuleContext, RuleSet
+
+
+class RuleEngine:
+    def __init__(self, rules: tuple[Rule, ...]) -> None:
+        duplicates = self._duplicate_ids(rules)
+        if duplicates:
+            raise ValueError(f'Duplicate rule ids registered: {sorted(duplicates)}')
+        self._rules = rules
+
+    @property
+    def rule_ids(self) -> tuple[str, ...]:
+        return tuple(rule.meta.rule_id for rule in self._rules)
+
+    def run(self, document: Document, blocks: tuple[CommentBlock, ...], rules: RuleSet) -> tuple[Diagnostic, ...]:
+        context = RuleContext(document=document, rules=rules)
+        active = [rule for rule in self._rules if rules.is_enabled(rule.meta.rule_id)]
+        found: list[Diagnostic] = []
+        for block in blocks:
+            for rule in active:
+                for diagnostic in rule.check(block, context):
+                    found.append(self._with_severity(diagnostic, rule, rules))
+        return tuple(found)
+
+    def _with_severity(self, diagnostic: Diagnostic, rule: Rule, rules: RuleSet) -> Diagnostic:
+        severity = rules.severity_for(rule.meta)
+        if diagnostic.severity is severity:
+            return diagnostic
+        return dataclasses.replace(diagnostic, severity=severity)
+
+    def _duplicate_ids(self, rules: tuple[Rule, ...]) -> set[str]:
+        seen: set[str] = set()
+        duplicates: set[str] = set()
+        for rule in rules:
+            if rule.meta.rule_id in seen:
+                duplicates.add(rule.meta.rule_id)
+            seen.add(rule.meta.rule_id)
+        return duplicates
+
+
+class LintDocument:
+    def __init__(self, parser: SourceParser, engine: RuleEngine) -> None:
+        self._parser = parser
+        self._engine = engine
+
+    def run(self, document: Document, rules: RuleSet) -> Report:
+        if not self._parser.supports(document.language_id):
+            return Report()
+        blocks = self._parser.parse(document)
+        diagnostics = self._engine.run(document, blocks, rules)
+        ordered = sorted(diagnostics, key=lambda item: (item.range.start, item.rule_id))
+        return Report(tuple(ordered))

--- a/src/housestyle/domain/__init__.py
+++ b/src/housestyle/domain/__init__.py
@@ -12,6 +12,7 @@ from .document import Document
 from .ports import SourceParser
 from .position import Encoding, Position, PositionMap, SourceRange
 from .prose import BreakPoint, BreakStrength, Prose, Sentence
+from .rules import ConfigSource, Rule, RuleContext, RuleSet, RuleSettings
 from .text import TextEdit, apply_edits
 
 
@@ -22,6 +23,7 @@ __all__ = [
     'CommentForm',
     'CommentLine',
     'CommentPlacement',
+    'ConfigSource',
     'Diagnostic',
     'Document',
     'Encoding',
@@ -31,7 +33,11 @@ __all__ = [
     'PositionMap',
     'Prose',
     'Report',
+    'Rule',
+    'RuleContext',
     'RuleMeta',
+    'RuleSet',
+    'RuleSettings',
     'Sentence',
     'Severity',
     'SourceParser',

--- a/src/housestyle/domain/rules.py
+++ b/src/housestyle/domain/rules.py
@@ -1,0 +1,56 @@
+import dataclasses
+import typing
+
+from .comment import CommentBlock
+from .diagnostic import Diagnostic, RuleMeta, Severity
+from .document import Document
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RuleSettings:
+    severity: Severity | None = None
+    options: typing.Mapping[str, object] = dataclasses.field(default_factory=dict)
+
+    def integer(self, name: str, fallback: int) -> int:
+        value = self.options.get(name, fallback)
+        return value if isinstance(value, int) and not isinstance(value, bool) else fallback
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RuleSet:
+    enabled: frozenset[str]
+    settings: typing.Mapping[str, RuleSettings] = dataclasses.field(default_factory=dict)
+    line_width: int = 120
+
+    def is_enabled(self, rule_id: str) -> bool:
+        return rule_id in self.enabled
+
+    def settings_for(self, rule_id: str) -> RuleSettings:
+        return self.settings.get(rule_id, RuleSettings())
+
+    def severity_for(self, meta: RuleMeta) -> Severity:
+        return self.settings_for(meta.rule_id).severity or meta.default_severity
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RuleContext:
+    document: Document
+    rules: RuleSet
+
+    @property
+    def line_width(self) -> int:
+        return self.rules.line_width
+
+    def settings(self, rule_id: str) -> RuleSettings:
+        return self.rules.settings_for(rule_id)
+
+
+class Rule(typing.Protocol):
+    @property
+    def meta(self) -> RuleMeta: ...
+
+    def check(self, block: CommentBlock, context: RuleContext) -> typing.Iterable[Diagnostic]: ...
+
+
+class ConfigSource(typing.Protocol):
+    def resolve(self, path: str) -> RuleSet: ...

--- a/tests/test_linting.py
+++ b/tests/test_linting.py
@@ -1,0 +1,140 @@
+import pytest
+
+from housestyle.application import LintDocument, RuleEngine
+from housestyle.domain import (
+    CommentBlock,
+    Diagnostic,
+    Document,
+    Fix,
+    FixKind,
+    RuleContext,
+    RuleMeta,
+    RuleSet,
+    RuleSettings,
+    Severity,
+    SourceRange,
+    TextEdit,
+)
+from housestyle.infrastructure import DEFAULT_PARSER
+
+
+class RecordingRule:
+    def __init__(self, rule_id: str, fix_kind: FixKind = FixKind.REWRITE) -> None:
+        self.meta = RuleMeta(rule_id=rule_id, summary='test rule', fix_kind=fix_kind)
+        self.seen: list[str] = []
+
+    def check(self, block: CommentBlock, context: RuleContext):
+        self.seen.append(block.prose().flattened)
+        yield Diagnostic(
+            rule_id=self.meta.rule_id,
+            range=block.range,
+            message=f'{self.meta.rule_id} at width {context.line_width}',
+        )
+
+
+class SilentRule:
+    meta = RuleMeta(rule_id='silent', summary='never fires', fix_kind=FixKind.REWRITE)
+
+    def check(self, block: CommentBlock, context: RuleContext):
+        return ()
+
+
+def document(source: str) -> Document:
+    return Document(uri='file:///a.py', text=source, language_id='python')
+
+
+def rule_set(*ids: str, **kwargs: object) -> RuleSet:
+    return RuleSet(enabled=frozenset(ids), **kwargs)  # pyright: ignore[reportArgumentType]
+
+
+def test_duplicate_rule_ids_are_rejected() -> None:
+    with pytest.raises(ValueError, match='Duplicate rule ids'):
+        RuleEngine((RecordingRule('same'), RecordingRule('same')))
+
+
+def test_a_new_rule_needs_no_engine_change() -> None:
+    rule = RecordingRule('brand-new')
+    engine = RuleEngine((rule,))
+    assert engine.rule_ids == ('brand-new',)
+
+    report = LintDocument(DEFAULT_PARSER, engine).run(document('# a note\n'), rule_set('brand-new'))
+    assert [item.rule_id for item in report.diagnostics] == ['brand-new']
+    assert rule.seen == ['a note']
+
+
+def test_a_disabled_rule_does_not_run() -> None:
+    rule = RecordingRule('off')
+    LintDocument(DEFAULT_PARSER, RuleEngine((rule,))).run(document('# a note\n'), rule_set())
+    assert rule.seen == []
+
+
+def test_every_block_reaches_every_enabled_rule() -> None:
+    first, second = RecordingRule('first'), RecordingRule('second')
+    engine = RuleEngine((first, second))
+    LintDocument(DEFAULT_PARSER, engine).run(document('# one\nx = 1\n# two\n'), rule_set('first', 'second'))
+    assert first.seen == ['one', 'two']
+    assert second.seen == ['one', 'two']
+
+
+def test_severity_comes_from_configuration_when_set() -> None:
+    engine = RuleEngine((RecordingRule('tunable'),))
+    rules = rule_set('tunable', settings={'tunable': RuleSettings(severity=Severity.WARNING)})
+    report = LintDocument(DEFAULT_PARSER, engine).run(document('# note\n'), rules)
+    assert report.diagnostics[0].severity is Severity.WARNING
+
+
+def test_severity_falls_back_to_the_rule_default() -> None:
+    engine = RuleEngine((RecordingRule('plain'),))
+    report = LintDocument(DEFAULT_PARSER, engine).run(document('# note\n'), rule_set('plain'))
+    assert report.diagnostics[0].severity is Severity.ERROR
+
+
+def test_line_width_reaches_the_rule_through_the_context() -> None:
+    engine = RuleEngine((RecordingRule('widthy'),))
+    report = LintDocument(DEFAULT_PARSER, engine).run(document('# note\n'), rule_set('widthy', line_width=88))
+    assert 'width 88' in report.diagnostics[0].message
+
+
+def test_an_unsupported_language_produces_an_empty_report() -> None:
+    engine = RuleEngine((RecordingRule('any'),))
+    unsupported = Document(uri='a.rb', text='# note', language_id='ruby')
+    assert LintDocument(DEFAULT_PARSER, engine).run(unsupported, rule_set('any')).is_clean
+
+
+def test_a_rule_that_never_fires_produces_a_clean_report() -> None:
+    engine = RuleEngine((SilentRule(),))
+    assert LintDocument(DEFAULT_PARSER, engine).run(document('# note\n'), rule_set('silent')).is_clean
+
+
+def test_diagnostics_come_back_in_source_order() -> None:
+    engine = RuleEngine((RecordingRule('a'), RecordingRule('b')))
+    report = LintDocument(DEFAULT_PARSER, engine).run(document('# one\nx = 1\n# two\n'), rule_set('a', 'b'))
+    starts = [item.range.start for item in report.diagnostics]
+    assert starts == sorted(starts)
+
+
+def test_rule_settings_read_integer_options_defensively() -> None:
+    settings = RuleSettings(options={'width': 90, 'flag': True, 'name': 'x'})
+    assert settings.integer('width', 120) == 90
+    assert settings.integer('flag', 120) == 120
+    assert settings.integer('name', 120) == 120
+    assert settings.integer('missing', 120) == 120
+
+
+def test_a_fix_kind_survives_the_engine() -> None:
+    class FixingRule:
+        meta = RuleMeta(rule_id='fixer', summary='fixes', fix_kind=FixKind.TARGETED)
+
+        def check(self, block: CommentBlock, context: RuleContext):
+            edit = TextEdit(SourceRange(block.range.start, block.range.start), '!')
+            yield Diagnostic(
+                rule_id='fixer',
+                range=block.range,
+                message='fix me',
+                fix=Fix.targeted(edit),
+            )
+
+    engine = RuleEngine((FixingRule(),))
+    report = LintDocument(DEFAULT_PARSER, engine).run(document('# note\n'), rule_set('fixer'))
+    assert report.mechanical and report.mechanical[0].fix is not None
+    assert report.mechanical[0].fix.kind is FixKind.TARGETED


### PR DESCRIPTION
The pure core every frontend calls, plus the vocabulary rules are written against.

- `Rule` protocol, `RuleSet`, `RuleSettings`, `RuleContext` in domain
- `RuleEngine` doing a single traversal and dispatching to every enabled rule
- `LintDocument` as `(Document, RuleSet) -> Report`, with no filesystem access

Adding a rule must never mean editing the engine, and that is checked rather than asserted: a test registers a throwaway rule and it runs with no engine change.

Registering two rules under one id raises, because a silent collision would quietly drop one.

Severity resolves from configuration with the rule's own default as fallback, so a rule can state its intent without hard coding this project's policy.

202 tests.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)