### PR TITLE
Implement policy B reflow and the layout rules

### DIFF
--- a/src/housestyle/domain/comment.py
+++ b/src/housestyle/domain/comment.py
@@ -2,7 +2,7 @@ import dataclasses
 import enum
 
 from .position import SourceRange
-from .prose import Prose
+from .prose import Prose, reflow_sentence
 from .text import TextEdit
 
 
@@ -95,6 +95,58 @@ class CommentBlock:
             for line in self.lines
         ]
         return Prose('\n'.join(rendered))
+
+    def reflow(self, width: int) -> 'CommentBlock':
+        payloads = self._reflowed_payloads(width)
+        if not payloads:
+            return self
+        return self._rebuild(payloads)
+
+    def _reflowed_payloads(self, width: int) -> tuple[str, ...]:
+        budget = max(20, width - self.lines[0].prefix_width)
+        out: list[str] = []
+        for paragraph, is_literal in self._paragraphs():
+            if out:
+                out.append('')
+            if is_literal:
+                out.extend(paragraph)
+                continue
+            joined = ' '.join(line.strip() for line in paragraph if line.strip())
+            for sentence in Prose(joined).sentences():
+                out.extend(reflow_sentence(sentence.text, budget))
+        return tuple(out)
+
+    def _paragraphs(self) -> tuple[tuple[tuple[str, ...], bool], ...]:
+        found: list[tuple[tuple[str, ...], bool]] = []
+        for segment in self.prose().segments():
+            current: list[str] = []
+            for line in segment.lines:
+                if line.strip():
+                    current.append(line)
+                elif current:
+                    found.append((tuple(current), segment.is_literal))
+                    current = []
+            if current:
+                found.append((tuple(current), segment.is_literal))
+        return tuple(found)
+
+    def _rebuild(self, payloads: tuple[str, ...]) -> 'CommentBlock':
+        if self.form is not CommentForm.DOC:
+            return self.with_payloads(payloads)
+        opening, closing = self.lines[0], self.lines[-1]
+        closes_alone = len(self.lines) > 1 and not closing.payload.strip()
+        body = [
+            dataclasses.replace(opening, marker='', suffix='', payload=payload, range=opening.range)
+            for payload in payloads
+        ]
+        body[0] = dataclasses.replace(body[0], marker=opening.marker)
+        if closes_alone or len(payloads) > 1:
+            body.append(dataclasses.replace(closing, marker=closing.marker or opening.marker, payload='', suffix=''))
+            if not closes_alone:
+                body[-1] = dataclasses.replace(body[-1], marker=opening.marker.strip())
+        else:
+            body[0] = dataclasses.replace(body[0], suffix=closing.suffix or opening.marker.strip())
+        return dataclasses.replace(self, lines=tuple(body))
 
     def with_payloads(self, payloads: tuple[str, ...]) -> 'CommentBlock':
         if not payloads:

--- a/src/housestyle/domain/prose.py
+++ b/src/housestyle/domain/prose.py
@@ -183,3 +183,39 @@ class Prose:
         if rest[0] in '"\')]}':
             rest = rest[1:]
         return not rest or rest[0] == ' '
+
+
+def reflow_sentence(sentence: str, width: int) -> tuple[str, ...]:
+    if len(sentence) <= width:
+        return (sentence,)
+    pieces = _comma_pieces(sentence)
+    if len(pieces) == 1:
+        return (sentence,)
+    return _pack(pieces, width)
+
+
+def _comma_pieces(sentence: str) -> tuple[str, ...]:
+    pieces: list[str] = []
+    start = 0
+    for match in re.finditer(r',\s+', sentence):
+        pieces.append(sentence[start : match.end()].rstrip())
+        start = match.end()
+    tail = sentence[start:].strip()
+    if tail:
+        pieces.append(tail)
+    return tuple(pieces) if pieces else (sentence,)
+
+
+def _pack(pieces: tuple[str, ...], width: int) -> tuple[str, ...]:
+    lines: list[str] = []
+    current = ''
+    for piece in pieces:
+        candidate = f'{current} {piece}'.strip() if current else piece
+        if current and len(candidate) > width:
+            lines.append(current)
+            current = piece
+        else:
+            current = candidate
+    if current:
+        lines.append(current)
+    return tuple(lines)

--- a/src/housestyle/infrastructure/__init__.py
+++ b/src/housestyle/infrastructure/__init__.py
@@ -1,7 +1,8 @@
 from .languages import PYTHON
 from .parser import TreeSitterParser
+from .rules import LAYOUT_RULES
 
 
 DEFAULT_PARSER = TreeSitterParser((PYTHON,))
 
-__all__ = ['DEFAULT_PARSER', 'PYTHON', 'TreeSitterParser']
+__all__ = ['DEFAULT_PARSER', 'LAYOUT_RULES', 'PYTHON', 'TreeSitterParser']

--- a/src/housestyle/infrastructure/rules/__init__.py
+++ b/src/housestyle/infrastructure/rules/__init__.py
@@ -1,0 +1,6 @@
+from .layout import LineWidthRule, WrapPointRule
+
+
+LAYOUT_RULES = (WrapPointRule(), LineWidthRule())
+
+__all__ = ['LAYOUT_RULES', 'LineWidthRule', 'WrapPointRule']

--- a/src/housestyle/infrastructure/rules/layout.py
+++ b/src/housestyle/infrastructure/rules/layout.py
@@ -1,0 +1,58 @@
+import typing
+
+from ...domain.comment import CommentBlock
+from ...domain.diagnostic import Diagnostic, Fix, FixKind, RuleMeta
+from ...domain.rules import RuleContext
+
+
+WRAP_POINT = RuleMeta(
+    rule_id='wrap-point',
+    summary='A comment block must be laid out one sentence per line, splitting only at commas.',
+    fix_kind=FixKind.REFLOW,
+)
+
+LINE_WIDTH = RuleMeta(
+    rule_id='line-width',
+    summary='A physical comment line must fit the configured width, counting indent and marker.',
+    fix_kind=FixKind.REFLOW,
+)
+
+
+class WrapPointRule:
+    meta = WRAP_POINT
+
+    def check(self, block: CommentBlock, context: RuleContext) -> typing.Iterable[Diagnostic]:
+        reflowed = block.reflow(context.line_width)
+        current = block.render()
+        if reflowed.render() == current:
+            return
+        yield Diagnostic(
+            rule_id=self.meta.rule_id,
+            range=block.range,
+            message=(
+                'Comment layout differs from one sentence per line. '
+                'Break only at a period or a comma, never mid clause.'
+            ),
+            fix=Fix.reflow(reflowed.as_edit()),
+        )
+
+
+class LineWidthRule:
+    meta = LINE_WIDTH
+
+    def check(self, block: CommentBlock, context: RuleContext) -> typing.Iterable[Diagnostic]:
+        width = context.line_width
+        if block.widest_line <= width:
+            return
+        reflowed = block.reflow(width)
+        if reflowed.widest_line > width:
+            return
+        yield Diagnostic(
+            rule_id=self.meta.rule_id,
+            range=block.range,
+            message=(
+                f'A comment line runs to {block.widest_line} characters against a limit of {width}, '
+                'counting indent and marker.'
+            ),
+            fix=Fix.reflow(reflowed.as_edit()),
+        )

--- a/tests/test_rules_layout.py
+++ b/tests/test_rules_layout.py
@@ -1,0 +1,109 @@
+import pytest
+
+from housestyle.application import LintDocument, RuleEngine
+from housestyle.domain import Document, FixKind, RuleSet, apply_edits
+from housestyle.infrastructure import DEFAULT_PARSER, LAYOUT_RULES
+
+
+ALL_LAYOUT = frozenset({'wrap-point', 'line-width'})
+
+
+def lint(source: str, width: int = 60, enabled: frozenset[str] = ALL_LAYOUT):
+    document = Document(uri='file:///a.py', text=source, language_id='python')
+    return LintDocument(DEFAULT_PARSER, RuleEngine(LAYOUT_RULES)).run(
+        document, RuleSet(enabled=enabled, line_width=width)
+    )
+
+
+def fixed(source: str, width: int = 60) -> str:
+    report = lint(source, width)
+    edits = tuple(edit for item in report.mechanical if item.fix for edit in item.fix.edits)
+    return apply_edits(source, edits[:1]) if edits else source
+
+
+def test_already_correct_layout_is_clean() -> None:
+    assert lint('def f():\n    # one sentence here.\n    pass\n').is_clean
+
+
+def test_a_mid_clause_break_is_reported_and_reflowed() -> None:
+    source = 'def f():\n    # cap the size to the limit so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n'
+    report = lint(source)
+    assert 'wrap-point' in [item.rule_id for item in report.diagnostics]
+    assert '# cap the size to the limit so the mmap does not blow past it,\n' in fixed(source)
+
+
+def test_reflow_splits_one_sentence_per_line() -> None:
+    source = 'def f():\n    # first one. second one. third one.\n    pass\n'
+    result = fixed(source)
+    assert result.count('    # ') == 3
+
+
+def test_a_long_sentence_splits_at_commas_only() -> None:
+    source = 'def f():\n    # this is long indeed, it carries clauses, and it ends here.\n    pass\n'
+    for line in fixed(source, width=40).splitlines():
+        if line.strip().startswith('#'):
+            assert line.rstrip().endswith((',', '.')) or line.strip() == '#'
+
+
+def test_a_sentence_with_no_comma_is_left_alone_by_reflow() -> None:
+    source = 'def f():\n    # this single sentence has no comma at all and cannot be split anywhere.\n    pass\n'
+    assert fixed(source, width=40) == source
+
+
+def test_line_width_counts_indent_and_marker() -> None:
+    payload = 'a padded payload here, and a tail clause that follows.'
+    shallow = f'def a():\n    # {payload}\n    pass\n'
+    deep = f'def a():\n    def b():\n        def c():\n            # {payload}\n            pass\n'
+
+    width = len(f'    # {payload}') + 1
+    assert 'line-width' not in [item.rule_id for item in lint(shallow, width=width).diagnostics]
+    assert 'line-width' in [item.rule_id for item in lint(deep, width=width).diagnostics]
+
+
+def test_line_width_stays_silent_when_the_block_already_fits() -> None:
+    source = 'def f():\n    # short.\n    pass\n'
+    assert 'line-width' not in [item.rule_id for item in lint(source, width=80).diagnostics]
+
+
+def test_line_width_stays_silent_when_reflow_cannot_help() -> None:
+    long_word = 'a' * 90
+    source = f'def f():\n    # {long_word}.\n    pass\n'
+    assert 'line-width' not in [item.rule_id for item in lint(source, width=40).diagnostics]
+
+
+def test_layout_fixes_are_reflow_kind() -> None:
+    source = 'def f():\n    # one. two.\n    pass\n'
+    for item in lint(source).diagnostics:
+        assert item.fix is not None
+        assert item.fix.kind is FixKind.REFLOW
+        assert item.is_mechanical
+
+
+def test_reflow_is_idempotent_on_its_own_output() -> None:
+    source = 'def f():\n    # cap the size to the limit so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n'
+    once = fixed(source)
+    assert fixed(once) == once
+
+
+def test_a_docstring_keeps_its_delimiters_through_reflow() -> None:
+    source = 'def f():\n    """Summary here, with a clause that runs on and on and needs a split.\n    """\n'
+    result = fixed(source, width=40)
+    assert result.count('"""') == 2
+    assert result.rstrip().endswith('"""')
+
+
+def test_a_single_line_docstring_stays_on_one_line() -> None:
+    source = 'def f():\n    """Short."""\n'
+    assert fixed(source, width=80) == source
+
+
+def test_a_literal_block_survives_reflow_untouched() -> None:
+    source = 'def f():\n    """Summary.\n\n        literal_code(1)\n\n    Tail prose, with a comma.\n    """\n'
+    assert '        literal_code(1)' in fixed(source, width=40)
+
+
+@pytest.mark.parametrize('rule_id', sorted(ALL_LAYOUT))
+def test_each_rule_can_be_disabled_independently(rule_id: str) -> None:
+    source = 'def f():\n    # cap the size to the limit so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n'
+    ids = [item.rule_id for item in lint(source, enabled=ALL_LAYOUT - {rule_id}).diagnostics]
+    assert rule_id not in ids


### PR DESCRIPTION
The core of the project. One sentence per line, splitting only at commas.

## Reflow

```
BEFORE                                    AFTER (width 60)
# cap size to the CI mmap limit,          # cap size to the CI mmap limit,
# an unbounded value faults the runner.   # an unbounded value faults the runner.
# retry later if it fails.                # retry later if it fails.

# this is long indeed, it carries         # this is long indeed,
# clauses, and it ends here.              # it carries clauses,
                                          # and it ends here.
```

Break points are periods and commas, never mid clause, so the layout is deterministic and reflowing the output again changes nothing. That is pinned by test.

## Docstrings needed their own path

The line comment path applies one marker per line. Docstrings do not work that way, and the first attempt lost the closing `"""`, flattened literal indentation, and was not idempotent. Now:

- the opening delimiter stays on the first line
- a closing delimiter that had its own line keeps it
- a one line docstring that still fits stays on one line
- literal paragraphs pass through with indentation intact

## line-width

Counts indent and marker, not payload. That is the exact gap that made Vale unusable for width here, and it is checked with a test that lints the **same payload** at two indentation depths and asserts only the deep one fires.

It stays silent when reflow cannot get the block under the limit, because those cases have no mechanical answer. They belong to `unbreakable-sentence`, which reports rather than rewrites.

217 tests.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)