### PR TITLE
Add the rules that only the author can resolve

### DIFF
--- a/src/housestyle/infrastructure/__init__.py
+++ b/src/housestyle/infrastructure/__init__.py
@@ -1,8 +1,8 @@
 from .languages import PYTHON
 from .parser import TreeSitterParser
-from .rules import LAYOUT_RULES
+from .rules import ALL_RULES, LAYOUT_RULES, REWRITE_RULES
 
 
 DEFAULT_PARSER = TreeSitterParser((PYTHON,))
 
-__all__ = ['DEFAULT_PARSER', 'LAYOUT_RULES', 'PYTHON', 'TreeSitterParser']
+__all__ = ['ALL_RULES', 'DEFAULT_PARSER', 'LAYOUT_RULES', 'PYTHON', 'REWRITE_RULES', 'TreeSitterParser']

--- a/src/housestyle/infrastructure/rules/__init__.py
+++ b/src/housestyle/infrastructure/rules/__init__.py
@@ -1,6 +1,17 @@
 from .layout import LineWidthRule, WrapPointRule
+from .rewrite import StubFragmentRule, UnbreakableSentenceRule
 
 
 LAYOUT_RULES = (WrapPointRule(), LineWidthRule())
+REWRITE_RULES = (StubFragmentRule(), UnbreakableSentenceRule())
+ALL_RULES = LAYOUT_RULES + REWRITE_RULES
 
-__all__ = ['LAYOUT_RULES', 'LineWidthRule', 'WrapPointRule']
+__all__ = [
+    'ALL_RULES',
+    'LAYOUT_RULES',
+    'REWRITE_RULES',
+    'LineWidthRule',
+    'StubFragmentRule',
+    'UnbreakableSentenceRule',
+    'WrapPointRule',
+]

--- a/src/housestyle/infrastructure/rules/rewrite.py
+++ b/src/housestyle/infrastructure/rules/rewrite.py
@@ -1,0 +1,80 @@
+import typing
+
+from ...domain.comment import CommentBlock
+from ...domain.diagnostic import Diagnostic, Fix, FixKind, RuleMeta
+from ...domain.prose import Prose, reflow_sentence
+from ...domain.rules import RuleContext
+
+
+STUB_FRAGMENT = RuleMeta(
+    rule_id='stub-fragment',
+    summary='A sentence forced to break must not leave a stub of a line behind.',
+    fix_kind=FixKind.REWRITE,
+)
+
+UNBREAKABLE_SENTENCE = RuleMeta(
+    rule_id='unbreakable-sentence',
+    summary='A sentence over the width must carry a comma so it has somewhere legal to break.',
+    fix_kind=FixKind.REWRITE,
+)
+
+DEFAULT_MINIMUM_CHARACTERS = 24
+
+
+def prose_sentences(block: CommentBlock) -> tuple[str, ...]:
+    return tuple(
+        sentence.text
+        for segment in block.prose().segments()
+        if not segment.is_literal
+        for sentence in Prose(segment.text).sentences()
+    )
+
+
+def sentence_budget(block: CommentBlock, context: RuleContext) -> int:
+    return max(20, context.line_width - block.lines[0].prefix_width)
+
+
+class StubFragmentRule:
+    meta = STUB_FRAGMENT
+
+    def check(self, block: CommentBlock, context: RuleContext) -> typing.Iterable[Diagnostic]:
+        budget = sentence_budget(block, context)
+        floor = context.settings(self.meta.rule_id).integer('minimum_characters', DEFAULT_MINIMUM_CHARACTERS)
+        for sentence in prose_sentences(block):
+            pieces = reflow_sentence(sentence, budget)
+            if len(pieces) < 2:
+                continue
+            shortest = min(pieces, key=len)
+            if len(shortest) >= floor:
+                continue
+            yield Diagnostic(
+                rule_id=self.meta.rule_id,
+                range=block.range,
+                message=(
+                    f'Breaking this sentence leaves a {len(shortest)} character line, below the '
+                    f'{floor} character floor, so the layout reads as a stub rather than a clause. '
+                    f'Rewrite it to fit one line, or split it into two complete sentences. '
+                    f'The fragment is "{shortest.strip()}".'
+                ),
+                fix=Fix.rewrite(),
+            )
+
+
+class UnbreakableSentenceRule:
+    meta = UNBREAKABLE_SENTENCE
+
+    def check(self, block: CommentBlock, context: RuleContext) -> typing.Iterable[Diagnostic]:
+        budget = max(20, context.line_width - block.lines[0].prefix_width)
+        for sentence in prose_sentences(block):
+            if len(sentence) <= budget or ',' in sentence:
+                continue
+            yield Diagnostic(
+                rule_id=self.meta.rule_id,
+                range=block.range,
+                message=(
+                    f'This sentence runs to {len(sentence)} characters against a {budget} character budget '
+                    'and contains no comma, so there is no legal place to break it. '
+                    'Add a comma at a clause boundary, or split it into two sentences.'
+                ),
+                fix=Fix.rewrite(),
+            )

--- a/tests/test_rules_rewrite.py
+++ b/tests/test_rules_rewrite.py
@@ -1,0 +1,99 @@
+import pytest
+
+from housestyle.application import LintDocument, RuleEngine
+from housestyle.domain import Document, FixKind, RuleSet, RuleSettings
+from housestyle.infrastructure import ALL_RULES, DEFAULT_PARSER
+
+
+REWRITE_IDS = frozenset({'stub-fragment', 'unbreakable-sentence'})
+
+
+def lint(source: str, width: int = 50, enabled: frozenset[str] = REWRITE_IDS, **settings: RuleSettings):
+    document = Document(uri='file:///a.py', text=source, language_id='python')
+    return LintDocument(DEFAULT_PARSER, RuleEngine(ALL_RULES)).run(
+        document, RuleSet(enabled=enabled, line_width=width, settings=settings)
+    )
+
+
+def ids(source: str, **kwargs) -> list[str]:
+    return [item.rule_id for item in lint(source, **kwargs).diagnostics]
+
+
+def comment(text: str) -> str:
+    return f'def f():\n    # {text}\n    pass\n'
+
+
+def test_a_short_standalone_sentence_is_not_a_stub() -> None:
+    assert ids(comment('brief.')) == []
+
+
+def test_a_sentence_that_fits_is_never_flagged() -> None:
+    assert ids(comment('this one fits inside the budget fine.')) == []
+
+
+def test_a_forced_break_leaving_a_stub_is_reported() -> None:
+    assert 'stub-fragment' in ids(comment('cap the size to the shared runner ceiling limit that we set here, ok.'))
+
+
+def test_a_balanced_split_is_not_a_stub() -> None:
+    assert 'stub-fragment' not in ids(comment('cap the size to the runner limit, an unbounded value faults it.'))
+
+
+def test_the_stub_floor_is_configurable() -> None:
+    source = comment('cap the size to the runner limit, an unbounded value faults it.')
+    assert 'stub-fragment' in ids(source, **{'stub-fragment': RuleSettings(options={'minimum_characters': 40})})
+
+
+def test_a_long_sentence_with_no_comma_is_unbreakable() -> None:
+    assert 'unbreakable-sentence' in ids(comment('this single sentence has no comma anywhere and runs well past it.'))
+
+
+def test_a_long_sentence_with_a_comma_is_breakable() -> None:
+    assert 'unbreakable-sentence' not in ids(comment('this sentence is long, but it carries a comma to break at.'))
+
+
+def test_a_short_sentence_without_a_comma_is_fine() -> None:
+    assert 'unbreakable-sentence' not in ids(comment('no comma here.'))
+
+
+def test_rewrite_diagnostics_carry_no_edits_and_reach_the_author() -> None:
+    report = lint(comment('this single sentence has no comma anywhere and runs well past it.'))
+    for item in report.needing_author:
+        assert item.fix is not None
+        assert item.fix.kind is FixKind.REWRITE
+        assert item.fix.edits == ()
+        assert not item.is_mechanical
+
+
+def test_the_message_states_the_concrete_fix() -> None:
+    report = lint(comment('this single sentence has no comma anywhere and runs well past it.'))
+    message = report.needing_author[0].message
+    assert 'no comma' in message
+    assert 'Add a comma' in message or 'split it into two sentences' in message
+
+
+def test_the_stub_message_quotes_the_offending_fragment() -> None:
+    report = lint(comment('cap the size to the shared runner ceiling limit that we set here, ok.'))
+    stub = next(item for item in report.needing_author if item.rule_id == 'stub-fragment')
+    assert '"ok."' in stub.message
+
+
+def test_a_literal_block_is_never_flagged() -> None:
+    source = 'def f():\n    """Summary.\n\n        a_very_long_literal_line_with_no_comma_at_all_here_indeed(1234567890)\n    """\n'
+    assert ids(source) == []
+
+
+def test_the_budget_shrinks_with_indentation() -> None:
+    payload = 'this sentence has no comma and sits at some depth in the file.'
+    shallow = f'def a():\n    # {payload}\n    pass\n'
+    deep = f'def a():\n    def b():\n        def c():\n            # {payload}\n            pass\n'
+    width = len(f'    # {payload}') + 1
+
+    assert 'unbreakable-sentence' not in ids(shallow, width=width)
+    assert 'unbreakable-sentence' in ids(deep, width=width)
+
+
+@pytest.mark.parametrize('rule_id', sorted(REWRITE_IDS))
+def test_each_rule_can_be_disabled_independently(rule_id: str) -> None:
+    source = comment('cap the size to the shared runner ceiling limit that we set here, ok.')
+    assert rule_id not in ids(source, enabled=REWRITE_IDS - {rule_id})


### PR DESCRIPTION
The first `REWRITE` rules, and therefore the only diagnostics that reach the agent at all.

- **`stub-fragment`** fires when a sentence forced to break leaves a piece too short to read as a clause. It fires only on split sentences, never on a short standalone one.
- **`unbreakable-sentence`** fires when a sentence exceeds the budget and contains no comma, so policy B has no legal break point.

Messages state the concrete fix and quote the offending text. A model that has to consult the rule docs before acting has already cost more attention than the finding is worth.

## A threshold the measurement killed

The stub floor started as 40% of the width budget. Measuring it showed the premise was wrong: **a budget scales with the configured width, but the readability of a fragment does not.** At width 120 that floor is 46 characters, which flags ordinary clauses.

Across 85 split sentences in the corpus:

```
shortest piece   min=16  p10=34  p25=44  median=58  max=101

floor 20 →   3 findings
floor 24 →   3 findings
floor 40 →  15 findings
floor 46 →  25 findings   ← the old percentage rule
```

An absolute floor of 24 catches the genuine tail. It is configurable via `minimum_characters`.

## Signal volume on the real corpus

| | before | after |
| --- | --- | --- |
| reaching the agent | 28 | **9** |
| fixed silently | 26 | 26 |

Nine findings across 55 files, roughly one per six files, against 26 that the tool repairs without ever telling the model.

232 tests.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)