### PR TITLE
Add the CLI, configuration, and self-hosting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - run: uv sync --extra dev
       - run: uv run pytest tests/ -v --tb=short
 
+      - name: Self-hosting
+        run: uv run housestyle check src/
+
   prose:
     name: Prose
     runs-on: ubuntu-latest

--- a/housestyle.toml
+++ b/housestyle.toml
@@ -1,0 +1,8 @@
+[housestyle]
+line-width = 120
+
+[rules]
+wrap-point = "error"
+line-width = "error"
+stub-fragment = "error"
+unbreakable-sentence = "error"

--- a/src/housestyle/domain/comment.py
+++ b/src/housestyle/domain/comment.py
@@ -112,9 +112,16 @@ class CommentBlock:
                 out.extend(paragraph)
                 continue
             joined = ' '.join(line.strip() for line in paragraph if line.strip())
-            for sentence in Prose(joined).sentences():
+            sentences = Prose(joined).sentences()
+            if any(len(item.text) > budget and ',' not in item.text for item in sentences):
+                out.extend(paragraph)
+                continue
+            for sentence in sentences:
                 out.extend(reflow_sentence(sentence.text, budget))
         return tuple(out)
+
+    def fits(self, width: int) -> bool:
+        return self.widest_line <= width
 
     def _paragraphs(self) -> tuple[tuple[tuple[str, ...], bool], ...]:
         found: list[tuple[tuple[str, ...], bool]] = []

--- a/src/housestyle/domain/prose.py
+++ b/src/housestyle/domain/prose.py
@@ -24,6 +24,7 @@ _TRAILING_WORD = re.compile(r'([A-Za-z][A-Za-z.]*)$')
 _URL = re.compile(r'\b(?:https?://|www\.)\S+')
 _CODE_SPAN = re.compile(r'`[^`]*`')
 _FENCE = re.compile(r'^\s*(```|~~~)')
+_LIST_MARKER = re.compile(r'^\s*(?:[0-9]+[.)]|[-*+]|[a-zA-Z][.)])\s')
 _LITERAL_MARKER = '\\b'
 
 
@@ -97,7 +98,7 @@ class Prose:
                 flush(next_literal=fenced)
                 current.append(line)
                 continue
-            flush(next_literal=fenced or held or self._is_indented(line))
+            flush(next_literal=fenced or held or self._is_indented(line) or self._is_list_item(line))
             current.append(line)
 
         if current:
@@ -106,6 +107,9 @@ class Prose:
 
     def _is_indented(self, line: str) -> bool:
         return line.startswith(('    ', '\t'))
+
+    def _is_list_item(self, line: str) -> bool:
+        return bool(_LIST_MARKER.match(line))
 
     @property
     def flattened(self) -> str:

--- a/src/housestyle/infrastructure/__init__.py
+++ b/src/housestyle/infrastructure/__init__.py
@@ -1,8 +1,20 @@
+from .config import CONFIG_NAME, TomlConfigSource
 from .languages import PYTHON
 from .parser import TreeSitterParser
 from .rules import ALL_RULES, LAYOUT_RULES, REWRITE_RULES
 
 
 DEFAULT_PARSER = TreeSitterParser((PYTHON,))
+DEFAULT_CONFIG = TomlConfigSource(tuple(rule.meta.rule_id for rule in ALL_RULES))
 
-__all__ = ['ALL_RULES', 'DEFAULT_PARSER', 'LAYOUT_RULES', 'PYTHON', 'REWRITE_RULES', 'TreeSitterParser']
+__all__ = [
+    'ALL_RULES',
+    'CONFIG_NAME',
+    'DEFAULT_CONFIG',
+    'DEFAULT_PARSER',
+    'LAYOUT_RULES',
+    'PYTHON',
+    'REWRITE_RULES',
+    'TomlConfigSource',
+    'TreeSitterParser',
+]

--- a/src/housestyle/infrastructure/config.py
+++ b/src/housestyle/infrastructure/config.py
@@ -1,0 +1,64 @@
+import pathlib
+import tomllib
+import typing
+
+from ..domain.diagnostic import Severity
+from ..domain.rules import RuleSet, RuleSettings
+
+
+CONFIG_NAME = 'housestyle.toml'
+DEFAULT_WIDTH = 120
+
+SEVERITIES = {severity.name.lower(): severity for severity in Severity}
+
+
+class TomlConfigSource:
+    def __init__(self, available: tuple[str, ...]) -> None:
+        self._available = available
+
+    def resolve(self, path: str) -> RuleSet:
+        found = self._locate(pathlib.Path(path))
+        if found is None:
+            return self.defaults()
+        return self._parse(tomllib.loads(found.read_text(encoding='utf-8')))
+
+    def defaults(self) -> RuleSet:
+        return RuleSet(enabled=frozenset(self._available), line_width=DEFAULT_WIDTH)
+
+    def _locate(self, start: pathlib.Path) -> pathlib.Path | None:
+        base = start if start.is_dir() else start.parent
+        for candidate in (base.resolve(), *base.resolve().parents):
+            found = candidate / CONFIG_NAME
+            if found.is_file():
+                return found
+        return None
+
+    def _parse(self, raw: typing.Mapping[str, object]) -> RuleSet:
+        root = raw.get('housestyle')
+        width = DEFAULT_WIDTH
+        if isinstance(root, dict):
+            candidate = root.get('line-width')
+            if isinstance(candidate, int) and not isinstance(candidate, bool):
+                width = candidate
+
+        section = raw.get('rules')
+        rules = section if isinstance(section, dict) else {}
+        enabled: set[str] = set(self._available)
+        settings: dict[str, RuleSettings] = {}
+
+        for rule_id, value in rules.items():
+            if rule_id not in self._available:
+                continue
+            if value is False or value == 'off':
+                enabled.discard(rule_id)
+                continue
+            if isinstance(value, str):
+                settings[rule_id] = RuleSettings(severity=SEVERITIES.get(value))
+            elif isinstance(value, dict):
+                severity = value.get('severity')
+                options = {key: item for key, item in value.items() if key != 'severity'}
+                settings[rule_id] = RuleSettings(
+                    severity=SEVERITIES.get(severity) if isinstance(severity, str) else None,
+                    options=options,
+                )
+        return RuleSet(enabled=frozenset(enabled), settings=settings, line_width=width)

--- a/src/housestyle/infrastructure/rules/layout.py
+++ b/src/housestyle/infrastructure/rules/layout.py
@@ -23,8 +23,7 @@ class WrapPointRule:
 
     def check(self, block: CommentBlock, context: RuleContext) -> typing.Iterable[Diagnostic]:
         reflowed = block.reflow(context.line_width)
-        current = block.render()
-        if reflowed.render() == current:
+        if reflowed.render() == block.render():
             return
         yield Diagnostic(
             rule_id=self.meta.rule_id,

--- a/src/housestyle/presentation/cli.py
+++ b/src/housestyle/presentation/cli.py
@@ -1,17 +1,21 @@
+import difflib
 import pathlib
 import sys
+import typing
 
 import typer
 
 from .. import __version__
-from ..application import CorpusStatistics, MeasureCorpus
+from ..application import CorpusStatistics, FixDocument, LintDocument, MeasureCorpus, RuleEngine
 from ..domain.document import Document
-from ..infrastructure import DEFAULT_PARSER, PYTHON
+from ..infrastructure import ALL_RULES, DEFAULT_CONFIG, DEFAULT_PARSER, PYTHON
+from . import report as reporters
 
 
 app = typer.Typer(add_completion=False, help='A linter and formatter for the prose inside code comments.')
 
 PERCENTILES = (0.5, 0.75, 0.9, 0.95, 0.99)
+FORMATTERS = {'human': reporters.human, 'agent': reporters.agent, 'json': reporters.as_json}
 
 
 def _load(paths: tuple[pathlib.Path, ...]) -> tuple[Document, ...]:
@@ -31,30 +35,101 @@ def _load(paths: tuple[pathlib.Path, ...]) -> tuple[Document, ...]:
     return tuple(documents)
 
 
+def _lint() -> LintDocument:
+    return LintDocument(DEFAULT_PARSER, RuleEngine(ALL_RULES))
+
+
+def _require(documents: tuple[Document, ...]) -> None:
+    if not documents:
+        typer.echo('No readable source files found.', err=True)
+        raise typer.Exit(1)
+
+
+@app.command()
+def check(
+    paths: list[pathlib.Path] = typer.Argument(..., help='Files or directories to check.'),
+    output: str = typer.Option('human', '--output', help='human, agent, or json.'),
+) -> None:
+    documents = _load(tuple(paths))
+    _require(documents)
+    formatter = FORMATTERS.get(output)
+    if formatter is None:
+        typer.echo(f'Unknown output format {output!r}. Choose human, agent, or json.', err=True)
+        raise typer.Exit(2)
+
+    lint = _lint()
+    findings = 0
+    for document in documents:
+        result = lint.run(document, DEFAULT_CONFIG.resolve(_fspath(document)))
+        findings += len(result.diagnostics)
+        rendered = formatter(document, result)
+        if rendered:
+            typer.echo(rendered)
+    raise typer.Exit(1 if findings else 0)
+
+
+@app.command()
+def fix(
+    paths: list[pathlib.Path] = typer.Argument(..., help='Files or directories to fix.'),
+    write: bool = typer.Option(False, '--write', help='Write changes instead of printing a diff.'),
+) -> None:
+    documents = _load(tuple(paths))
+    _require(documents)
+
+    fixer = FixDocument(_lint())
+    changed = 0
+    remaining = 0
+    for document in documents:
+        outcome = fixer.run(document, DEFAULT_CONFIG.resolve(_fspath(document)))
+        remaining += len(outcome.remaining)
+        if outcome.changed:
+            changed += 1
+            if write:
+                pathlib.Path(_fspath(document)).write_text(outcome.document.text, encoding='utf-8')
+            else:
+                typer.echo(_diff(document, outcome.document))
+        if outcome.remaining:
+            typer.echo(reporters.agent(outcome.document, outcome.report))
+
+    verb = 'rewrote' if write else 'would rewrite'
+    typer.echo(f'{verb} {changed} of {len(documents)} files, {remaining} findings need an author.', err=True)
+    raise typer.Exit(1 if remaining else 0)
+
+
+@app.command()
+def stats(paths: list[pathlib.Path] = typer.Argument(..., help='Files or directories to measure.')) -> None:
+    documents = _load(tuple(paths))
+    _require(documents)
+    typer.echo(_render(MeasureCorpus(DEFAULT_PARSER).run(documents)))
+
+
+@app.command()
+def version() -> None:
+    typer.echo(f'housestyle {__version__}')
+
+
+def _fspath(document: Document) -> str:
+    return document.uri.removeprefix('file://')
+
+
+def _diff(before: Document, after: Document) -> str:
+    path = _fspath(before)
+    return ''.join(
+        difflib.unified_diff(
+            before.text.splitlines(keepends=True),
+            after.text.splitlines(keepends=True),
+            fromfile=path,
+            tofile=path,
+        )
+    ).rstrip()
+
+
 def _render(report: CorpusStatistics) -> str:
-    header = f'{report.documents} documents, {report.blocks} comment blocks'
-    lines = [
-        header,
-        '',
-        'block line counts',
-        f'{"group":24s} {"n":>6s} {"med":>5s} ' + ' '.join(f'p{int(p * 100):<3d}' for p in PERCENTILES) + '  max',
-    ]
-    for distribution in report.line_counts:
-        cells = ' '.join(f'{distribution.percentile(p):<4d}' for p in PERCENTILES)
-        lines.append(
-            f'{distribution.label:24s} {distribution.count:6d} {distribution.median:5d} {cells} {distribution.maximum:4d}'
-        )
-
+    heading = f'{"group":24s} {"n":>6s} {"med":>5s} ' + ' '.join(f'p{int(p * 100):<3d}' for p in PERCENTILES) + '  max'
+    lines = [f'{report.documents} documents, {report.blocks} comment blocks', '', 'block line counts', heading]
+    lines.extend(_row(distribution.label, distribution) for distribution in report.line_counts)
     for distribution in (report.physical_widths, report.sentence_lengths):
-        cells = ' '.join(f'{distribution.percentile(p):<4d}' for p in PERCENTILES)
-        lines.extend(
-            [
-                '',
-                distribution.label,
-                f'{"":24s} {distribution.count:6d} {distribution.median:5d} {cells} {distribution.maximum:4d}',
-            ]
-        )
-
+        lines.extend(['', distribution.label, _row('', distribution)])
     lines.extend(['', 'sentences over width with no comma to break at'])
     for width, count in report.unbreakable_at:
         share = count / report.sentence_lengths.count * 100 if report.sentence_lengths.count else 0.0
@@ -62,18 +137,9 @@ def _render(report: CorpusStatistics) -> str:
     return '\n'.join(lines)
 
 
-@app.command()
-def stats(paths: list[pathlib.Path] = typer.Argument(..., help='Files or directories to measure.')) -> None:
-    documents = _load(tuple(paths))
-    if not documents:
-        typer.echo('No readable source files found.', err=True)
-        raise typer.Exit(1)
-    typer.echo(_render(MeasureCorpus(DEFAULT_PARSER).run(documents)))
-
-
-@app.command()
-def version() -> None:
-    typer.echo(f'housestyle {__version__}')
+def _row(label: str, distribution: typing.Any) -> str:
+    cells = ' '.join(f'{distribution.percentile(p):<4d}' for p in PERCENTILES)
+    return f'{label:24s} {distribution.count:6d} {distribution.median:5d} {cells} {distribution.maximum:4d}'
 
 
 def main() -> int:

--- a/src/housestyle/presentation/report.py
+++ b/src/housestyle/presentation/report.py
@@ -1,0 +1,61 @@
+import json
+
+from ..domain.diagnostic import Diagnostic, Report
+from ..domain.document import Document
+
+
+def human(document: Document, report: Report) -> str:
+    if report.is_clean:
+        return ''
+    lines: list[str] = []
+    for item in report.diagnostics:
+        position = document.positions.to_position(item.range.start)
+        location = f'{_path(document)}:{position.line + 1}:{position.character + 1}'
+        lines.append(f'{location}  {item.severity.name.lower()}  {item.rule_id}  {item.message}')
+    return '\n'.join(lines)
+
+
+def agent(document: Document, report: Report) -> str:
+    if not report.needing_author:
+        return ''
+    lines = [
+        f'{len(report.needing_author)} comment findings need rewriting in {_path(document)}.',
+        'Each states the fix. Apply it in place, do not add a suppression comment.',
+        '',
+    ]
+    for item in report.needing_author:
+        position = document.positions.to_position(item.range.start)
+        lines.append(f'line {position.line + 1}  [{item.rule_id}]')
+        lines.append(f'  {item.message}')
+    return '\n'.join(lines)
+
+
+def as_json(document: Document, report: Report) -> str:
+    return json.dumps(
+        {
+            'uri': document.uri,
+            'diagnostics': [_encode(document, item) for item in report.diagnostics],
+            'unavailable_sources': list(report.unavailable_sources),
+        },
+        indent=2,
+    )
+
+
+def _encode(document: Document, item: Diagnostic) -> dict[str, object]:
+    start = document.positions.to_position(item.range.start)
+    end = document.positions.to_position(item.range.end)
+    return {
+        'rule': item.rule_id,
+        'severity': item.severity.name.lower(),
+        'message': item.message,
+        'fixKind': item.fix.kind.value if item.fix else None,
+        'mechanical': item.is_mechanical,
+        'range': {
+            'start': {'line': start.line, 'character': start.character},
+            'end': {'line': end.line, 'character': end.character},
+        },
+    }
+
+
+def _path(document: Document) -> str:
+    return document.uri.removeprefix('file://')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,3 +32,97 @@ def test_stats_exits_non_zero_when_nothing_is_readable(tmp_path: pathlib.Path) -
     with pytest.raises(SystemExit) as exit_info:
         app(['stats', str(tmp_path)])
     assert exit_info.value.code == 1
+
+
+def test_check_reports_findings_and_exits_non_zero(tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    target = tmp_path / 'bad.py'
+    target.write_text(
+        'def f():\n    # cap the size so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n',
+        encoding='utf-8',
+    )
+    (tmp_path / 'housestyle.toml').write_text('[housestyle]\nline-width = 60\n', encoding='utf-8')
+
+    with pytest.raises(SystemExit) as exit_info:
+        app(['check', str(target)])
+    assert exit_info.value.code == 1
+    assert 'wrap-point' in capsys.readouterr().out
+
+
+def test_check_on_clean_input_exits_zero(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / 'good.py'
+    target.write_text('def f():\n    # short and fine.\n    pass\n', encoding='utf-8')
+    with pytest.raises(SystemExit) as exit_info:
+        app(['check', str(target)])
+    assert exit_info.value.code == 0
+
+
+def test_check_rejects_an_unknown_output_format(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / 'a.py'
+    target.write_text('# note\n', encoding='utf-8')
+    with pytest.raises(SystemExit) as exit_info:
+        app(['check', str(target), '--output', 'nonsense'])
+    assert exit_info.value.code == 2
+
+
+def test_fix_prints_a_diff_without_write(tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    target = tmp_path / 'bad.py'
+    original = (
+        'def f():\n    # cap the size so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n'
+    )
+    target.write_text(original, encoding='utf-8')
+    (tmp_path / 'housestyle.toml').write_text('[housestyle]\nline-width = 60\n', encoding='utf-8')
+
+    with pytest.raises(SystemExit):
+        app(['fix', str(target)])
+    assert '---' in capsys.readouterr().out
+    assert target.read_text(encoding='utf-8') == original
+
+
+def test_fix_write_applies_the_change(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / 'bad.py'
+    original = (
+        'def f():\n    # cap the size so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n'
+    )
+    target.write_text(original, encoding='utf-8')
+    (tmp_path / 'housestyle.toml').write_text('[housestyle]\nline-width = 60\n', encoding='utf-8')
+
+    with pytest.raises(SystemExit):
+        app(['fix', str(target), '--write'])
+    assert target.read_text(encoding='utf-8') != original
+    assert 'does not blow past it,' in target.read_text(encoding='utf-8')
+
+
+def test_the_agent_format_shows_only_findings_needing_an_author(
+    tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / 'a.py'
+    target.write_text(
+        'def f():\n    # this single sentence has no comma anywhere and runs well past the budget here.\n    pass\n',
+        encoding='utf-8',
+    )
+    (tmp_path / 'housestyle.toml').write_text('[housestyle]\nline-width = 50\n', encoding='utf-8')
+
+    with pytest.raises(SystemExit):
+        app(['check', str(target), '--output', 'agent'])
+    output = capsys.readouterr().out
+    assert 'unbreakable-sentence' in output
+    assert 'do not add a suppression comment' in output
+
+
+def test_the_json_format_encodes_ranges_and_fix_kind(
+    tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import json
+
+    target = tmp_path / 'a.py'
+    target.write_text(
+        'def f():\n    # cap the size so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n',
+        encoding='utf-8',
+    )
+    (tmp_path / 'housestyle.toml').write_text('[housestyle]\nline-width = 60\n', encoding='utf-8')
+
+    with pytest.raises(SystemExit):
+        app(['check', str(target), '--output', 'json'])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['diagnostics'][0]['fixKind'] == 'reflow'
+    assert payload['diagnostics'][0]['mechanical'] is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,61 @@
+import pathlib
+
+from housestyle.domain import Severity
+from housestyle.infrastructure import CONFIG_NAME, TomlConfigSource
+
+
+AVAILABLE = ('wrap-point', 'line-width', 'stub-fragment')
+
+
+def source() -> TomlConfigSource:
+    return TomlConfigSource(AVAILABLE)
+
+
+def write(directory: pathlib.Path, body: str) -> pathlib.Path:
+    (directory / CONFIG_NAME).write_text(body, encoding='utf-8')
+    target = directory / 'module.py'
+    target.write_text('# note\n', encoding='utf-8')
+    return target
+
+
+def test_defaults_enable_every_available_rule(tmp_path: pathlib.Path) -> None:
+    rules = source().resolve(str(tmp_path))
+    assert rules.enabled == frozenset(AVAILABLE)
+    assert rules.line_width == 120
+
+
+def test_configuration_is_found_by_walking_upward(tmp_path: pathlib.Path) -> None:
+    nested = tmp_path / 'a' / 'b'
+    nested.mkdir(parents=True)
+    write(tmp_path, '[housestyle]\nline-width = 88\n')
+    assert source().resolve(str(nested / 'module.py')).line_width == 88
+
+
+def test_a_rule_can_be_switched_off(tmp_path: pathlib.Path) -> None:
+    target = write(tmp_path, '[rules]\nwrap-point = false\n')
+    rules = source().resolve(str(target))
+    assert not rules.is_enabled('wrap-point')
+    assert rules.is_enabled('line-width')
+
+
+def test_a_severity_string_is_honoured(tmp_path: pathlib.Path) -> None:
+    target = write(tmp_path, '[rules]\nwrap-point = "warning"\n')
+    rules = source().resolve(str(target))
+    assert rules.settings_for('wrap-point').severity is Severity.WARNING
+
+
+def test_a_table_carries_severity_and_options(tmp_path: pathlib.Path) -> None:
+    target = write(tmp_path, '[rules]\nstub-fragment = { severity = "warning", minimum_characters = 30 }\n')
+    settings = source().resolve(str(target)).settings_for('stub-fragment')
+    assert settings.severity is Severity.WARNING
+    assert settings.integer('minimum_characters', 24) == 30
+
+
+def test_an_unknown_rule_is_ignored(tmp_path: pathlib.Path) -> None:
+    target = write(tmp_path, '[rules]\nnot-a-rule = false\n')
+    assert source().resolve(str(target)).enabled == frozenset(AVAILABLE)
+
+
+def test_a_nonsense_width_falls_back_to_the_default(tmp_path: pathlib.Path) -> None:
+    target = write(tmp_path, '[housestyle]\nline-width = "wide"\n')
+    assert source().resolve(str(target)).line_width == 120

--- a/tests/test_prose.py
+++ b/tests/test_prose.py
@@ -161,3 +161,21 @@ def test_prose_without_literal_blocks_is_unchanged() -> None:
     prose = Prose('cap the size to the limit,\nan unbounded value faults')
     assert [segment.is_literal for segment in prose.segments()] == [False]
     assert prose.flattened == 'cap the size to the limit, an unbounded value faults'
+
+
+@pytest.mark.parametrize(
+    'line',
+    ['1. first item here', '2) second item', '- a bullet', '* another bullet', '+ a third', 'a. lettered item'],
+)
+def test_a_list_item_is_literal_structure(line: str) -> None:
+    prose = Prose(f'Lead in.\n\n{line}\n\nTail prose.')
+    assert any(segment.is_literal and line in segment.lines for segment in prose.segments())
+
+
+def test_a_numbered_list_is_not_split_into_marker_and_body() -> None:
+    prose = Prose('Order:\n\n1. Detect the flows.\n2. Pick one per entry.\n\nTail.')
+    assert [sentence.text for sentence in prose.sentences()] == ['Order: Tail.']
+
+
+def test_a_decimal_is_still_not_a_list_marker() -> None:
+    assert len(Prose('the cap is 3.14 percent of the budget').sentences()) == 1

--- a/tests/test_rules_layout.py
+++ b/tests/test_rules_layout.py
@@ -107,3 +107,21 @@ def test_each_rule_can_be_disabled_independently(rule_id: str) -> None:
     source = 'def f():\n    # cap the size to the limit so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n'
     ids = [item.rule_id for item in lint(source, enabled=ALL_LAYOUT - {rule_id}).diagnostics]
     assert rule_id not in ids
+
+
+def test_a_paragraph_with_no_legal_break_is_left_as_the_author_wrote_it() -> None:
+    source = (
+        'def f():\n'
+        '    """Summary.\n\n'
+        '    No comma appears here:\n'
+        '    and this continuation carries the rest of a very long sentence indeed.\n'
+        '    """\n'
+    )
+    assert fixed(source, width=60) == source
+
+
+def test_a_numbered_list_survives_reflow() -> None:
+    source = 'def f():\n    """Order:\n\n    1. Detect the flows first.\n    2. Pick one per entry, otherwise fall back.\n    """\n'
+    result = fixed(source, width=60)
+    assert '1. Detect the flows first.' in result
+    assert '2. Pick one per entry, otherwise fall back.' in result

--- a/tests/test_self_hosting.py
+++ b/tests/test_self_hosting.py
@@ -1,0 +1,79 @@
+import pathlib
+
+import pytest
+
+from housestyle.application import LintDocument, RuleEngine
+from housestyle.domain import Document, RuleSet
+from housestyle.infrastructure import ALL_RULES, DEFAULT_CONFIG, DEFAULT_PARSER, PYTHON
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SOURCE_ROOT = REPO_ROOT / 'src'
+
+
+def lint_text(text: str, rules: RuleSet | None = None):
+    document = Document(uri='file:///probe.py', text=text, language_id=PYTHON.language_id)
+    engine = RuleEngine(ALL_RULES)
+    return LintDocument(DEFAULT_PARSER, engine).run(document, rules or DEFAULT_CONFIG.resolve(str(SOURCE_ROOT)))
+
+
+def source_files() -> list[pathlib.Path]:
+    return sorted(SOURCE_ROOT.rglob('*.py'))
+
+
+def test_the_corpus_is_not_empty() -> None:
+    assert len(source_files()) > 10
+
+
+def test_the_project_carries_comments_worth_checking() -> None:
+    blocks = 0
+    for path in source_files():
+        document = Document(
+            uri=path.resolve().as_uri(),
+            text=path.read_text(encoding='utf-8'),
+            language_id=PYTHON.language_id,
+        )
+        blocks += len(DEFAULT_PARSER.parse(document))
+    assert blocks > 0, 'a clean self-hosting run means nothing if there is nothing to check'
+
+
+def test_housestyle_lints_itself_clean() -> None:
+    rules = DEFAULT_CONFIG.resolve(str(SOURCE_ROOT))
+    engine = RuleEngine(ALL_RULES)
+    lint = LintDocument(DEFAULT_PARSER, engine)
+
+    findings: list[str] = []
+    for path in source_files():
+        document = Document(
+            uri=path.resolve().as_uri(),
+            text=path.read_text(encoding='utf-8'),
+            language_id=PYTHON.language_id,
+        )
+        for item in lint.run(document, rules).diagnostics:
+            findings.append(f'{path.relative_to(REPO_ROOT)}: {item.rule_id} {item.message[:80]}')
+    assert not findings, f'{len(findings)} self-hosting findings: {findings[:5]}'
+
+
+@pytest.mark.parametrize(
+    ('probe', 'expected'),
+    [
+        (
+            'def f():\n    # cap the size so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n',
+            'wrap-point',
+        ),
+        (
+            'def f():\n    # this single sentence carries no comma at all and runs a very long way past any '
+            'sensible budget that a reader would tolerate on one line.\n    pass\n',
+            'unbreakable-sentence',
+        ),
+    ],
+)
+def test_the_self_hosting_check_has_teeth(probe: str, expected: str) -> None:
+    rules = RuleSet(enabled=frozenset(rule.meta.rule_id for rule in ALL_RULES), line_width=60)
+    assert expected in [item.rule_id for item in lint_text(probe, rules).diagnostics]
+
+
+def test_the_project_config_is_readable_and_enables_every_rule() -> None:
+    rules = DEFAULT_CONFIG.resolve(str(SOURCE_ROOT))
+    assert rules.enabled == frozenset(rule.meta.rule_id for rule in ALL_RULES)
+    assert rules.line_width == 120


### PR DESCRIPTION
Closes the loop. `housestyle check src/` now runs in CI against this repo.

- `check` and `fix` over the pure core, with `human`, `agent`, and `json` reporters
- `fix` defaults to a diff, writes only under `--write`
- `housestyle.toml`, found by walking upward from the file being checked
- A `Self-hosting` job in CI

## Two faults only the real corpus found

Unit fixtures were clean. Running `fix` over openapi-mcp-gateway was not.

**Lists were being flattened.** A list marker reads as a sentence terminator, so `1. Detect the flows.` split into `1.` and the body, and the items then merged into one paragraph:

```diff
-    1. Detect all OAuth flows declared in the spec.
-    2. Pick one per ``entry.auth.flow`` if set.
+    1. Detect all OAuth flows declared in the spec. 2. Pick one per
+    ``entry.auth.flow`` if set.
```

Lists are structure, not prose, so they pass through as literal now.

**Reflow was making files worse.** A paragraph whose sentence carries no comma was being joined into one 143 character line, which then got reported as `unbreakable-sentence`. The file lost the author's readable arrangement *and* the agent got a message. It now leaves such a paragraph untouched and reports only the missing comma, because joining gains nothing when no legal break exists.

My first attempt at this suppressed any reflow that would overflow, which also silenced genuine mid-clause breaks that happened to fit. The narrower rule is the correct one.

## Self-hosting

Clean, but that is only meaningful with two guards, both present: one seeds violations to prove the check can fail, another asserts the project actually carries comment blocks worth checking.

## Corpus impact

| | |
| --- | --- |
| files | 58 |
| rewritten mechanically | 12 |
| reaching the agent | 8 |

269 tests.

Closes #12
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)