### PR TITLE
Add the Claude Code hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@ Rules fall into three tiers. Most of them are shared across every language.
 - **Structural, per-language binding**: doc comment form, file header comments, signature-restating tags
 - **Genuinely per-language**: module docstrings, framework-specific description fields
 
+## Agent Hook
+
+Wire it into Claude Code so mechanical findings are repaired on write and only the rest reach the model.
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [{ "type": "command", "command": "housestyle-hook" }]
+      }
+    ]
+  }
+}
+```
+
+The hook reads the tool payload on stdin, repairs every mechanical finding in place without saying anything, and exits 2 only when a finding needs rewriting. Exit 2 sends the message back to the model, which is the one path by which anything reaches it.
+
+Silence on repaired findings is deliberate. Each surfaced message costs agent attention, and attention is the scarce resource this tool exists to protect.
+
 ## Frontends
 
 One pure core, `lint(text, path, config) -> Diagnostic[]`, behind several thin adapters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
 [project.scripts]
 housestyle = "housestyle.presentation.cli:main"
 hstyle = "housestyle.presentation.cli:main"
+housestyle-hook = "housestyle.presentation.hook:main"
 
 [project.urls]
 Homepage = "https://github.com/mroops0111/housestyle"

--- a/src/housestyle/domain/comment.py
+++ b/src/housestyle/domain/comment.py
@@ -112,11 +112,7 @@ class CommentBlock:
                 out.extend(paragraph)
                 continue
             joined = ' '.join(line.strip() for line in paragraph if line.strip())
-            sentences = Prose(joined).sentences()
-            if any(len(item.text) > budget and ',' not in item.text for item in sentences):
-                out.extend(paragraph)
-                continue
-            for sentence in sentences:
+            for sentence in Prose(joined).sentences():
                 out.extend(reflow_sentence(sentence.text, budget))
         return tuple(out)
 

--- a/src/housestyle/presentation/hook.py
+++ b/src/housestyle/presentation/hook.py
@@ -1,0 +1,84 @@
+import dataclasses
+import json
+import pathlib
+import sys
+import typing
+
+from ..application import FixDocument, LintDocument, RuleEngine
+from ..domain.document import Document
+from ..infrastructure import ALL_RULES, DEFAULT_CONFIG, DEFAULT_PARSER, PYTHON
+from . import report as reporters
+
+
+BLOCK_EXIT = 2
+EDIT_TOOLS = frozenset({'Edit', 'Write', 'MultiEdit', 'NotebookEdit'})
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class HookOutcome:
+    exit_code: int
+    stderr: str = ''
+    repaired: tuple[str, ...] = ()
+
+    @property
+    def blocks(self) -> bool:
+        return self.exit_code == BLOCK_EXIT
+
+
+def targets(payload: typing.Mapping[str, object]) -> tuple[pathlib.Path, ...]:
+    tool = payload.get('tool_name')
+    if isinstance(tool, str) and tool not in EDIT_TOOLS:
+        return ()
+    raw = payload.get('tool_input')
+    fields = raw if isinstance(raw, dict) else {}
+    found: list[pathlib.Path] = []
+    for key in ('file_path', 'notebook_path'):
+        value = fields.get(key)
+        if isinstance(value, str) and value:
+            found.append(pathlib.Path(value))
+    return tuple(path for path in found if path.suffix in PYTHON.extensions and path.is_file())
+
+
+def run(payload: typing.Mapping[str, object], *, write: bool = True) -> HookOutcome:
+    paths = targets(payload)
+    if not paths:
+        return HookOutcome(exit_code=0)
+
+    fixer = FixDocument(LintDocument(DEFAULT_PARSER, RuleEngine(ALL_RULES)))
+    messages: list[str] = []
+    repaired: list[str] = []
+
+    for path in paths:
+        try:
+            text = path.read_text(encoding='utf-8')
+        except (OSError, UnicodeDecodeError):
+            continue
+        document = Document(uri=path.resolve().as_uri(), text=text, language_id=PYTHON.language_id)
+        outcome = fixer.run(document, DEFAULT_CONFIG.resolve(str(path)))
+        if outcome.changed and write:
+            path.write_text(outcome.document.text, encoding='utf-8')
+            repaired.append(str(path))
+        rendered = reporters.agent(outcome.document, outcome.report)
+        if rendered:
+            messages.append(rendered)
+
+    if not messages:
+        return HookOutcome(exit_code=0, repaired=tuple(repaired))
+    return HookOutcome(exit_code=BLOCK_EXIT, stderr='\n\n'.join(messages), repaired=tuple(repaired))
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+    outcome = run(payload)
+    if outcome.stderr:
+        sys.stderr.write(outcome.stderr + '\n')
+    return outcome.exit_code
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,0 +1,123 @@
+import json
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+from housestyle.presentation import hook
+
+
+CONFIG = '[housestyle]\nline-width = 74\n'
+MIS_WRAPPED = (
+    'def f():\n'
+    '    # cap the size to the shared limit so the mmap does not\n'
+    '    # blow past it, an unbounded value faults the runner.\n'
+    '    pass\n'
+)
+UNBREAKABLE = (
+    'def f():\n    # this one carries no comma at all and runs a very long way past the budget here.\n    pass\n'
+)
+
+
+def payload(path: pathlib.Path, tool: str = 'Edit') -> dict[str, object]:
+    return {'tool_name': tool, 'tool_input': {'file_path': str(path)}}
+
+
+def seed(tmp_path: pathlib.Path, body: str, name: str = 'probe.py') -> pathlib.Path:
+    (tmp_path / 'housestyle.toml').write_text(CONFIG, encoding='utf-8')
+    target = tmp_path / name
+    target.write_text(body, encoding='utf-8')
+    return target
+
+
+def test_a_non_edit_tool_is_ignored(tmp_path: pathlib.Path) -> None:
+    target = seed(tmp_path, MIS_WRAPPED)
+    assert hook.run(payload(target, tool='Read')).exit_code == 0
+
+
+def test_a_non_python_file_is_ignored(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / 'notes.md'
+    target.write_text('# heading\n', encoding='utf-8')
+    assert hook.targets(payload(target)) == ()
+
+
+def test_a_missing_file_is_ignored(tmp_path: pathlib.Path) -> None:
+    assert hook.targets(payload(tmp_path / 'gone.py')) == ()
+
+
+def test_a_payload_without_a_path_is_ignored() -> None:
+    assert hook.run({'tool_name': 'Edit', 'tool_input': {}}).exit_code == 0
+
+
+def test_mechanical_findings_are_repaired_silently(tmp_path: pathlib.Path) -> None:
+    target = seed(tmp_path, MIS_WRAPPED)
+    outcome = hook.run(payload(target))
+
+    assert outcome.exit_code == 0
+    assert not outcome.blocks
+    assert outcome.stderr == ''
+    assert str(target) in outcome.repaired
+    assert 'does not blow past it,\n' in target.read_text(encoding='utf-8')
+
+
+def test_a_rewrite_finding_blocks_with_exit_two(tmp_path: pathlib.Path) -> None:
+    target = seed(tmp_path, UNBREAKABLE)
+    outcome = hook.run(payload(target))
+
+    assert outcome.exit_code == 2
+    assert outcome.blocks
+    assert 'unbreakable-sentence' in outcome.stderr
+    assert 'Add a comma' in outcome.stderr
+
+
+def test_a_clean_file_neither_writes_nor_blocks(tmp_path: pathlib.Path) -> None:
+    target = seed(tmp_path, 'def f():\n    # short and fine.\n    pass\n')
+    original = target.read_text(encoding='utf-8')
+    outcome = hook.run(payload(target))
+
+    assert outcome.exit_code == 0
+    assert outcome.repaired == ()
+    assert target.read_text(encoding='utf-8') == original
+
+
+def test_a_fixable_neighbour_is_repaired_even_when_the_run_blocks(tmp_path: pathlib.Path) -> None:
+    extra = '    # this trailing one carries no comma at all and runs a very long way past the budget here.\n'
+    body = MIS_WRAPPED.replace('    pass\n', extra + '    pass\n')
+    target = seed(tmp_path, body)
+    outcome = hook.run(payload(target))
+
+    assert outcome.blocks
+    assert 'does not blow past it,\n' in target.read_text(encoding='utf-8')
+
+
+def test_write_can_be_suppressed(tmp_path: pathlib.Path) -> None:
+    target = seed(tmp_path, MIS_WRAPPED)
+    original = target.read_text(encoding='utf-8')
+    hook.run(payload(target), write=False)
+    assert target.read_text(encoding='utf-8') == original
+
+
+@pytest.mark.parametrize('body', ['not json at all', '[]', '"a string"'])
+def test_malformed_input_never_blocks(body: str) -> None:
+    result = subprocess.run(
+        [sys.executable, '-m', 'housestyle.presentation.hook'],
+        input=body,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+
+
+def test_the_entry_point_blocks_on_a_rewrite_finding(tmp_path: pathlib.Path) -> None:
+    target = seed(tmp_path, UNBREAKABLE)
+    result = subprocess.run(
+        [sys.executable, '-m', 'housestyle.presentation.hook'],
+        input=json.dumps(payload(target)),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert 'unbreakable-sentence' in result.stderr

--- a/tests/test_rules_layout.py
+++ b/tests/test_rules_layout.py
@@ -109,15 +109,24 @@ def test_each_rule_can_be_disabled_independently(rule_id: str) -> None:
     assert rule_id not in ids
 
 
-def test_a_paragraph_with_no_legal_break_is_left_as_the_author_wrote_it() -> None:
+def test_an_unbreakable_sentence_still_gets_a_canonical_line() -> None:
+    source = 'def f():\n    # first one, with a comma. a second sentence with no comma runs past the budget here.\n    pass\n'
+    result = fixed(source, width=60)
+
+    assert '    # first one, with a comma.\n' in result
+    assert '    # a second sentence with no comma runs past the budget here.\n' in result
+
+
+def test_a_fixable_neighbour_is_repaired_even_beside_an_unbreakable_sentence() -> None:
     source = (
         'def f():\n'
-        '    """Summary.\n\n'
-        '    No comma appears here:\n'
-        '    and this continuation carries the rest of a very long sentence indeed.\n'
-        '    """\n'
+        '    # cap the size to the shared limit so the mmap does not\n'
+        '    # blow past it, an unbounded value faults the runner.\n'
+        '    # this one carries no comma at all and runs a very long way past the budget.\n'
+        '    pass\n'
     )
-    assert fixed(source, width=60) == source
+    result = fixed(source, width=74)
+    assert '# cap the size to the shared limit so the mmap does not blow past it,\n' in result
 
 
 def test_a_numbered_list_survives_reflow() -> None:


### PR DESCRIPTION
Closes the agent loop. The hook is the primary channel because it is the only involuntary one: a model will not go and read the rules, and will not choose to call a checker.

```json
{
  "hooks": {
    "PostToolUse": [
      { "matcher": "Edit|Write", "hooks": [{ "type": "command", "command": "housestyle-hook" }] }
    ]
  }
}
```

## Behaviour

| Finding | File | Model hears |
| --- | --- | --- |
| `TARGETED` / `REFLOW` | repaired in place | nothing, exit 0 |
| `REWRITE` | untouched | message on stderr, exit 2 |

Silence on repaired findings is the point. Every surfaced message costs agent attention.

End to end on a seeded file:

```
$ echo '{"tool_name":"Edit","tool_input":{"file_path":"probe.py"}}' | housestyle-hook
1 comment findings need rewriting in probe.py.
Each states the fix. Apply it in place, do not add a suppression comment.

line 2  [unbreakable-sentence]
  This sentence runs to 100 characters against a 74 character budget and contains
  no comma, so there is no legal place to break it. Add a comma at a clause
  boundary, or split it into two sentences.
exit=2
```

## A guard that was too coarse

Wiring this up exposed a fault in the reflow guard added with the CLI. Skipping a whole paragraph because one sentence had no comma **also skipped the fixable sentences beside it**, so a mid-clause break stayed in the file with nothing reported at all, which reads as clean.

Reflow now decides per sentence. A comment carrying both faults gets the first repaired and the second reported, which is checked by a test.

## Robustness

Malformed stdin never blocks. Non-edit tools, non-Python paths, and missing files are all ignored rather than erroring, because a hook that fails noisily on unrelated writes is worse than no hook.

289 tests.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)