### PR TITLE
Delegate to Vale and AutoCorrect behind a port

### DIFF
--- a/src/housestyle/application/__init__.py
+++ b/src/housestyle/application/__init__.py
@@ -1,9 +1,11 @@
+from .aggregating import Aggregator
 from .fixing import FixDocument, FixOutcome
 from .linting import LintDocument, RuleEngine
 from .statistics import CorpusStatistics, Distribution, MeasureCorpus
 
 
 __all__ = [
+    'Aggregator',
     'CorpusStatistics',
     'Distribution',
     'FixDocument',

--- a/src/housestyle/application/aggregating.py
+++ b/src/housestyle/application/aggregating.py
@@ -1,0 +1,23 @@
+from ..domain.diagnostic import Report
+from ..domain.document import Document
+from ..domain.external import ExternalLinter
+from ..domain.rules import RuleSet
+from .linting import LintDocument
+
+
+class Aggregator:
+    def __init__(self, lint: LintDocument, linters: tuple[ExternalLinter, ...] = ()) -> None:
+        self._lint = lint
+        self._linters = linters
+
+    def run(self, document: Document, rules: RuleSet) -> Report:
+        report = self._lint.run(document, rules)
+        unavailable: list[str] = []
+        for linter in self._linters:
+            if not linter.is_available():
+                unavailable.append(linter.name)
+                continue
+            report = report.merged_with(Report(linter.run(document)))
+        if unavailable:
+            report = report.merged_with(Report(unavailable_sources=tuple(unavailable)))
+        return report

--- a/src/housestyle/domain/__init__.py
+++ b/src/housestyle/domain/__init__.py
@@ -9,6 +9,7 @@ from .comment import (
 )
 from .diagnostic import Diagnostic, Fix, FixKind, Report, RuleMeta, Severity
 from .document import Document
+from .external import ExternalLinter
 from .ports import SourceParser
 from .position import Encoding, Position, PositionMap, SourceRange
 from .prose import BreakPoint, BreakStrength, Prose, Sentence
@@ -27,6 +28,7 @@ __all__ = [
     'Diagnostic',
     'Document',
     'Encoding',
+    'ExternalLinter',
     'Fix',
     'FixKind',
     'Position',

--- a/src/housestyle/domain/external.py
+++ b/src/housestyle/domain/external.py
@@ -1,0 +1,13 @@
+import typing
+
+from .diagnostic import Diagnostic
+from .document import Document
+
+
+class ExternalLinter(typing.Protocol):
+    @property
+    def name(self) -> str: ...
+
+    def is_available(self) -> bool: ...
+
+    def run(self, document: Document) -> tuple[Diagnostic, ...]: ...

--- a/src/housestyle/infrastructure/__init__.py
+++ b/src/housestyle/infrastructure/__init__.py
@@ -1,3 +1,4 @@
+from .adapters import AutoCorrectAdapter, ValeAdapter
 from .config import CONFIG_NAME, TomlConfigSource
 from .languages import PYTHON
 from .parser import TreeSitterParser
@@ -7,14 +8,19 @@ from .rules import ALL_RULES, LAYOUT_RULES, REWRITE_RULES
 DEFAULT_PARSER = TreeSitterParser((PYTHON,))
 DEFAULT_CONFIG = TomlConfigSource(tuple(rule.meta.rule_id for rule in ALL_RULES))
 
+EXTERNAL_LINTERS = (ValeAdapter(), AutoCorrectAdapter())
+
 __all__ = [
     'ALL_RULES',
     'CONFIG_NAME',
     'DEFAULT_CONFIG',
     'DEFAULT_PARSER',
+    'EXTERNAL_LINTERS',
     'LAYOUT_RULES',
     'PYTHON',
     'REWRITE_RULES',
+    'AutoCorrectAdapter',
     'TomlConfigSource',
     'TreeSitterParser',
+    'ValeAdapter',
 ]

--- a/src/housestyle/infrastructure/adapters/__init__.py
+++ b/src/housestyle/infrastructure/adapters/__init__.py
@@ -1,0 +1,5 @@
+from .autocorrect import AutoCorrectAdapter
+from .vale import ValeAdapter
+
+
+__all__ = ['AutoCorrectAdapter', 'ValeAdapter']

--- a/src/housestyle/infrastructure/adapters/autocorrect.py
+++ b/src/housestyle/infrastructure/adapters/autocorrect.py
@@ -1,0 +1,70 @@
+import pathlib
+import re
+import shutil
+import subprocess
+
+from ...domain.diagnostic import Diagnostic, Fix, Severity
+from ...domain.document import Document
+from ...domain.position import Position, SourceRange
+from ...domain.text import TextEdit
+
+
+LOCATION = re.compile(r'^(?P<path>.+?):(?P<line>\d+):(?P<column>\d+)$')
+TIMEOUT_SECONDS = 30
+RULE_ID = 'autocorrect/spacing'
+
+
+class AutoCorrectAdapter:
+    name = 'autocorrect'
+
+    def __init__(self, executable: str = 'autocorrect') -> None:
+        self._executable = executable
+
+    def is_available(self) -> bool:
+        return shutil.which(self._executable) is not None
+
+    def run(self, document: Document) -> tuple[Diagnostic, ...]:
+        path = pathlib.Path(document.uri.removeprefix('file://'))
+        if not self.is_available() or not path.is_file():
+            return ()
+        corrected = self._corrected(path)
+        if corrected is None or corrected == document.text:
+            return ()
+        return self._diff(document, corrected)
+
+    def _corrected(self, path: pathlib.Path) -> str | None:
+        try:
+            result = subprocess.run(  # noqa: S603
+                [self._executable, '--stdin', str(path)],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=TIMEOUT_SECONDS,
+                input=path.read_text(encoding='utf-8'),
+            )
+        except (OSError, UnicodeDecodeError, subprocess.TimeoutExpired):
+            return None
+        return result.stdout if result.stdout else None
+
+    def _diff(self, document: Document, corrected: str) -> tuple[Diagnostic, ...]:
+        before = document.text.splitlines(keepends=True)
+        after = corrected.splitlines(keepends=True)
+        if len(before) != len(after):
+            return ()
+        found: list[Diagnostic] = []
+        for index, (original, fixed) in enumerate(zip(before, after, strict=True)):
+            if original == fixed:
+                continue
+            start = document.positions.to_offset(Position(index, 0))
+            end = start + len(original.rstrip('\n').encode('utf-8'))
+            found.append(
+                Diagnostic(
+                    rule_id=RULE_ID,
+                    range=SourceRange(start, end),
+                    message='Spacing or punctuation between CJK and Latin text needs correcting.',
+                    severity=Severity.ERROR,
+                    fix=Fix.targeted(TextEdit(SourceRange(start, end), fixed.rstrip('\n'))),
+                    source=self.name,
+                )
+            )
+        return tuple(found)

--- a/src/housestyle/infrastructure/adapters/vale.py
+++ b/src/housestyle/infrastructure/adapters/vale.py
@@ -1,0 +1,84 @@
+import json
+import pathlib
+import shutil
+import subprocess
+
+from ...domain.diagnostic import Diagnostic, Fix, Severity
+from ...domain.document import Document
+from ...domain.position import Position, SourceRange
+
+
+SEVERITIES = {'error': Severity.ERROR, 'warning': Severity.WARNING, 'suggestion': Severity.SUGGESTION}
+TIMEOUT_SECONDS = 30
+
+
+class ValeAdapter:
+    name = 'vale'
+
+    def __init__(self, executable: str = 'vale') -> None:
+        self._executable = executable
+
+    def is_available(self) -> bool:
+        return shutil.which(self._executable) is not None
+
+    def run(self, document: Document) -> tuple[Diagnostic, ...]:
+        path = pathlib.Path(document.uri.removeprefix('file://'))
+        if not self.is_available() or not path.is_file():
+            return ()
+        try:
+            result = subprocess.run(  # noqa: S603
+                [self._executable, '--no-exit', '--output=JSON', str(path)],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return ()
+        return self._decode(document, result.stdout)
+
+    def _decode(self, document: Document, payload: str) -> tuple[Diagnostic, ...]:
+        try:
+            parsed = json.loads(payload or '{}')
+        except json.JSONDecodeError:
+            return ()
+        if not isinstance(parsed, dict):
+            return ()
+        found: list[Diagnostic] = []
+        for alerts in parsed.values():
+            if not isinstance(alerts, list):
+                continue
+            for alert in alerts:
+                if isinstance(alert, dict):
+                    diagnostic = self._one(document, alert)
+                    if diagnostic is not None:
+                        found.append(diagnostic)
+        return tuple(found)
+
+    def _one(self, document: Document, alert: dict[str, object]) -> Diagnostic | None:
+        line = alert.get('Line')
+        span = alert.get('Span')
+        check = alert.get('Check')
+        message = alert.get('Message')
+        if not isinstance(line, int) or not isinstance(check, str) or not isinstance(message, str):
+            return None
+        start_column, end_column = self._span(span)
+        try:
+            start = document.positions.to_offset(Position(line - 1, start_column - 1))
+            end = document.positions.to_offset(Position(line - 1, end_column))
+        except ValueError:
+            return None
+        severity = alert.get('Severity')
+        return Diagnostic(
+            rule_id=check,
+            range=SourceRange(start, max(start, end)),
+            message=message,
+            severity=SEVERITIES.get(severity, Severity.ERROR) if isinstance(severity, str) else Severity.ERROR,
+            fix=Fix.rewrite(),
+            source=self.name,
+        )
+
+    def _span(self, span: object) -> tuple[int, int]:
+        if isinstance(span, list) and len(span) == 2 and all(isinstance(item, int) for item in span):
+            return int(span[0]), int(span[1])
+        return 1, 1

--- a/src/housestyle/presentation/cli.py
+++ b/src/housestyle/presentation/cli.py
@@ -6,9 +6,9 @@ import typing
 import typer
 
 from .. import __version__
-from ..application import CorpusStatistics, FixDocument, LintDocument, MeasureCorpus, RuleEngine
+from ..application import Aggregator, CorpusStatistics, FixDocument, LintDocument, MeasureCorpus, RuleEngine
 from ..domain.document import Document
-from ..infrastructure import ALL_RULES, DEFAULT_CONFIG, DEFAULT_PARSER, PYTHON
+from ..infrastructure import ALL_RULES, DEFAULT_CONFIG, DEFAULT_PARSER, EXTERNAL_LINTERS, PYTHON
 from . import report as reporters
 
 
@@ -39,6 +39,10 @@ def _lint() -> LintDocument:
     return LintDocument(DEFAULT_PARSER, RuleEngine(ALL_RULES))
 
 
+def _aggregator(delegate: bool) -> Aggregator:
+    return Aggregator(_lint(), EXTERNAL_LINTERS if delegate else ())
+
+
 def _require(documents: tuple[Document, ...]) -> None:
     if not documents:
         typer.echo('No readable source files found.', err=True)
@@ -49,6 +53,7 @@ def _require(documents: tuple[Document, ...]) -> None:
 def check(
     paths: list[pathlib.Path] = typer.Argument(..., help='Files or directories to check.'),
     output: str = typer.Option('human', '--output', help='human, agent, or json.'),
+    delegate: bool = typer.Option(True, '--delegate/--no-delegate', help='Also run Vale and AutoCorrect.'),
 ) -> None:
     documents = _load(tuple(paths))
     _require(documents)
@@ -57,10 +62,10 @@ def check(
         typer.echo(f'Unknown output format {output!r}. Choose human, agent, or json.', err=True)
         raise typer.Exit(2)
 
-    lint = _lint()
+    aggregator = _aggregator(delegate)
     findings = 0
     for document in documents:
-        result = lint.run(document, DEFAULT_CONFIG.resolve(_fspath(document)))
+        result = aggregator.run(document, DEFAULT_CONFIG.resolve(_fspath(document)))
         findings += len(result.diagnostics)
         rendered = formatter(document, result)
         if rendered:

--- a/tests/test_aggregating.py
+++ b/tests/test_aggregating.py
@@ -1,0 +1,119 @@
+import pathlib
+import shutil
+
+import pytest
+
+from housestyle.application import Aggregator, LintDocument, RuleEngine
+from housestyle.domain import Diagnostic, Document, Fix, FixKind, RuleSet, SourceRange
+from housestyle.infrastructure import ALL_RULES, DEFAULT_PARSER, AutoCorrectAdapter, ValeAdapter
+
+
+ENABLED = frozenset(rule.meta.rule_id for rule in ALL_RULES)
+MIS_WRAPPED = (
+    'def f():\n    # cap the size so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n'
+)
+
+
+class StubLinter:
+    def __init__(self, name: str, available: bool = True, diagnostics: tuple[Diagnostic, ...] = ()) -> None:
+        self.name = name
+        self._available = available
+        self._diagnostics = diagnostics
+        self.calls = 0
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def run(self, document: Document) -> tuple[Diagnostic, ...]:
+        self.calls += 1
+        return self._diagnostics
+
+
+def finding(rule_id: str, start: int = 0, source: str = 'stub') -> Diagnostic:
+    return Diagnostic(
+        rule_id=rule_id,
+        range=SourceRange(start, start + 1),
+        message='from an external tool',
+        fix=Fix.rewrite(),
+        source=source,
+    )
+
+
+def document(text: str = MIS_WRAPPED) -> Document:
+    return Document(uri='file:///a.py', text=text, language_id='python')
+
+
+def aggregate(linters, text: str = MIS_WRAPPED, width: int = 60):
+    core = LintDocument(DEFAULT_PARSER, RuleEngine(ALL_RULES))
+    return Aggregator(core, linters).run(document(text), RuleSet(enabled=ENABLED, line_width=width))
+
+
+def test_native_findings_survive_with_no_linters() -> None:
+    report = aggregate(())
+    assert report.diagnostics
+    assert all(item.source == 'housestyle' for item in report.diagnostics)
+
+
+def test_external_findings_are_merged_in() -> None:
+    report = aggregate((StubLinter('stub', diagnostics=(finding('stub.Rule'),)),))
+    assert 'stub.Rule' in [item.rule_id for item in report.diagnostics]
+
+
+def test_an_unavailable_linter_is_recorded_rather_than_fatal() -> None:
+    linter = StubLinter('absent', available=False, diagnostics=(finding('never'),))
+    report = aggregate((linter,))
+    assert report.unavailable_sources == ('absent',)
+    assert linter.calls == 0
+    assert report.diagnostics
+
+
+def test_identical_findings_from_two_sources_are_deduplicated() -> None:
+    shared = finding('same.Rule', start=0)
+    report = aggregate((StubLinter('a', diagnostics=(shared,)), StubLinter('b', diagnostics=(shared,))))
+    assert [item.rule_id for item in report.diagnostics].count('same.Rule') == 1
+
+
+def test_findings_differing_by_position_are_both_kept() -> None:
+    linter = StubLinter('a', diagnostics=(finding('same.Rule', 0), finding('same.Rule', 40)))
+    report = aggregate((linter,))
+    assert [item.rule_id for item in report.diagnostics].count('same.Rule') == 2
+
+
+def test_external_rewrite_findings_reach_the_author_partition() -> None:
+    report = aggregate((StubLinter('a', diagnostics=(finding('stub.Rule'),)),))
+    assert 'stub.Rule' in [item.rule_id for item in report.needing_author]
+
+
+def test_mechanical_and_authored_findings_stay_separated() -> None:
+    report = aggregate((StubLinter('a', diagnostics=(finding('stub.Rule'),)),))
+    assert all(item.fix and item.fix.kind is FixKind.REFLOW for item in report.mechanical)
+    assert all(item.needs_author for item in report.needing_author)
+
+
+def test_a_clean_document_with_a_silent_linter_is_clean() -> None:
+    report = aggregate((StubLinter('a'),), text='def f():\n    # short and fine.\n    pass\n')
+    assert report.is_clean
+
+
+@pytest.mark.skipif(shutil.which('vale') is None, reason='vale is not installed')
+def test_the_vale_adapter_normalises_real_output(tmp_path: pathlib.Path) -> None:
+    repo_config = pathlib.Path(__file__).resolve().parent.parent / '.vale.ini'
+    shutil.copy(repo_config, tmp_path / '.vale.ini')
+    shutil.copytree(repo_config.parent / 'styles', tmp_path / 'styles')
+    target = tmp_path / 'probe.py'
+    target.write_text('def f():\n    # a semicolon; which is forbidden here.\n    pass\n', encoding='utf-8')
+
+    found = ValeAdapter().run(
+        Document(uri=target.resolve().as_uri(), text=target.read_text(encoding='utf-8'), language_id='python')
+    )
+    assert any('Semicolon' in item.rule_id for item in found)
+    assert all(item.source == 'vale' for item in found)
+    assert all(item.fix and item.fix.kind is FixKind.REWRITE for item in found)
+
+
+def test_adapters_report_absence_without_raising() -> None:
+    assert ValeAdapter(executable='definitely-not-installed').is_available() is False
+    assert AutoCorrectAdapter(executable='definitely-not-installed').is_available() is False
+    missing = Document(uri='file:///nowhere/gone.py', text='# note\n', language_id='python')
+    assert ValeAdapter(executable='definitely-not-installed').run(missing) == ()
+    assert AutoCorrectAdapter(executable='definitely-not-installed').run(missing) == ()


### PR DESCRIPTION
Completes M2.5. The content tier and the CJK tier now come from tools that already do them well, behind one port.

## The port

```python
class ExternalLinter(typing.Protocol):
    name: str
    def is_available(self) -> bool: ...
    def run(self, document: Document) -> tuple[Diagnostic, ...]: ...
```

Adapters return **normalised `Diagnostic` values**, never the tool's own shape. Vale's JSON never reaches the core, so a tier can be brought in house later by swapping one adapter and touching nothing else.

## The taxonomy earning its keep

| Source | Fix kind | Why |
| --- | --- | --- |
| Vale | `REWRITE` | Vale has no autofix at all, so only the author can act |
| AutoCorrect | `TARGETED` | it does have autofix, so the tool applies it silently |

This is exactly why `FixKind` classifies by **who can fix a thing** rather than by whether a fix exists. Two delegated tools, same port, opposite handling, no special cases in the core.

## Degraded runs stay visible

A missing tool is recorded in `unavailable_sources` and the run continues. Silently returning fewer findings because a binary was absent would read as clean.

## End to end

```
[housestyle] wrap-point:       Comment layout differs from one sentence per line...
[housestyle] line-width:       A comment line runs to 70 characters against a limit of 60...
[housestyle] stub-fragment:    Breaking this sentence leaves a 15 character line...
[vale]       mroops.Semicolon: Semicolon found. Split into two sentences or use a comma.
```

`check` gains `--no-delegate` for running the native tier alone.

299 tests.

Closes #22
Closes #24
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)