### PR TITLE
Add the structural rules and close the self-hosting gaps

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --project \"$CLAUDE_PROJECT_DIR\" housestyle-hook"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - run: uv run pytest tests/ -v --tb=short
 
       - name: Self-hosting
-        run: uv run housestyle check src/
+        run: uv run housestyle check src/ tests/
 
   prose:
     name: Prose

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Design notes stay local, not in git
-docs/
+# Design notes stay local. The generated rule reference is tracked.
+docs/*
+!docs/rules.md
 
 # Python
 __pycache__/

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,16 @@
+# Rules
+
+Generated from `RuleMeta`. Edit the rule, not this file.
+
+The fix kind states who resolves a finding. A mechanical kind is repaired without telling the author, so only a rewrite reaches an agent.
+
+| Rule | Fix kind | Summary |
+| --- | --- | --- |
+| `line-width` | reflow | A physical comment line must fit the configured width, counting indent and marker. |
+| `wrap-point` | reflow | A comment block must be laid out one sentence per line, splitting only at commas. |
+| `block-too-long` | rewrite | A comment block long enough to restate the code has stopped earning its place. |
+| `doc-comment-form` | rewrite | A public symbol must be documented in the doc comment form its language renders. |
+| `no-file-header` | rewrite | A file must not open with a banner comment before its first declaration. |
+| `no-signature-restating` | rewrite | A doc comment must not restate what the type signature already carries. |
+| `stub-fragment` | rewrite | A sentence forced to break must not leave a stub of a line behind. |
+| `unbreakable-sentence` | rewrite | A sentence over the width must carry a comma so it has somewhere legal to break. |

--- a/housestyle.toml
+++ b/housestyle.toml
@@ -1,8 +1,13 @@
 [housestyle]
 line-width = 120
+exclude = ["tests/fixtures/**"]
 
 [rules]
 wrap-point = "error"
 line-width = "error"
 stub-fragment = "error"
 unbreakable-sentence = "error"
+no-file-header = "error"
+doc-comment-form = "error"
+no-signature-restating = "error"
+block-too-long = "error"

--- a/src/housestyle/infrastructure/config.py
+++ b/src/housestyle/infrastructure/config.py
@@ -1,3 +1,4 @@
+import fnmatch
 import pathlib
 import tomllib
 import typing
@@ -21,6 +22,27 @@ class TomlConfigSource:
         if found is None:
             return self.defaults()
         return self._parse(tomllib.loads(found.read_text(encoding='utf-8')))
+
+    def excludes(self, path: str) -> tuple[str, ...]:
+        found = self._locate(pathlib.Path(path))
+        if found is None:
+            return ()
+        raw = tomllib.loads(found.read_text(encoding='utf-8')).get('housestyle')
+        patterns = raw.get('exclude') if isinstance(raw, dict) else None
+        if not isinstance(patterns, list):
+            return ()
+        return tuple(str(item) for item in patterns if isinstance(item, str))
+
+    def is_excluded(self, target: pathlib.Path, root: pathlib.Path, patterns: tuple[str, ...]) -> bool:
+        try:
+            relative = target.resolve().relative_to(root.resolve()).as_posix()
+        except ValueError:
+            relative = target.resolve().as_posix()
+        return any(fnmatch.fnmatch(relative, pattern) for pattern in patterns)
+
+    def root_for(self, path: str) -> pathlib.Path:
+        found = self._locate(pathlib.Path(path))
+        return found.parent if found else pathlib.Path.cwd()
 
     def defaults(self) -> RuleSet:
         return RuleSet(enabled=frozenset(self._available), line_width=DEFAULT_WIDTH)

--- a/src/housestyle/infrastructure/rules/__init__.py
+++ b/src/housestyle/infrastructure/rules/__init__.py
@@ -1,16 +1,29 @@
+from ..languages import PYTHON
 from .layout import LineWidthRule, WrapPointRule
 from .rewrite import StubFragmentRule, UnbreakableSentenceRule
+from .structural import BlockTooLongRule, DocCommentFormRule, NoFileHeaderRule, NoSignatureRestatingRule
 
 
 LAYOUT_RULES = (WrapPointRule(), LineWidthRule())
 REWRITE_RULES = (StubFragmentRule(), UnbreakableSentenceRule())
-ALL_RULES = LAYOUT_RULES + REWRITE_RULES
+STRUCTURAL_RULES = (
+    NoFileHeaderRule(),
+    DocCommentFormRule(PYTHON),
+    NoSignatureRestatingRule(PYTHON),
+    BlockTooLongRule(),
+)
+ALL_RULES = LAYOUT_RULES + REWRITE_RULES + STRUCTURAL_RULES
 
 __all__ = [
     'ALL_RULES',
     'LAYOUT_RULES',
     'REWRITE_RULES',
+    'STRUCTURAL_RULES',
+    'BlockTooLongRule',
+    'DocCommentFormRule',
     'LineWidthRule',
+    'NoFileHeaderRule',
+    'NoSignatureRestatingRule',
     'StubFragmentRule',
     'UnbreakableSentenceRule',
     'WrapPointRule',

--- a/src/housestyle/infrastructure/rules/structural.py
+++ b/src/housestyle/infrastructure/rules/structural.py
@@ -1,0 +1,136 @@
+import typing
+
+from ...domain.comment import CommentBlock, CommentForm, CommentPlacement
+from ...domain.diagnostic import Diagnostic, Fix, FixKind, RuleMeta
+from ...domain.rules import RuleContext
+from ..languages.base import LanguageConventions
+
+
+NO_FILE_HEADER = RuleMeta(
+    rule_id='no-file-header',
+    summary='A file must not open with a banner comment before its first declaration.',
+    fix_kind=FixKind.REWRITE,
+)
+
+DOC_COMMENT_FORM = RuleMeta(
+    rule_id='doc-comment-form',
+    summary='A public symbol must be documented in the doc comment form its language renders.',
+    fix_kind=FixKind.REWRITE,
+)
+
+NO_SIGNATURE_RESTATING = RuleMeta(
+    rule_id='no-signature-restating',
+    summary='A doc comment must not restate what the type signature already carries.',
+    fix_kind=FixKind.REWRITE,
+)
+
+
+class NoFileHeaderRule:
+    meta = NO_FILE_HEADER
+
+    def check(self, block: CommentBlock, context: RuleContext) -> typing.Iterable[Diagnostic]:
+        if block.placement is not CommentPlacement.FILE_HEADER:
+            return
+        yield Diagnostic(
+            rule_id=self.meta.rule_id,
+            range=block.range,
+            message=(
+                'This comment opens the file before any declaration. '
+                'A reader has the file, not a banner about it, so delete it. '
+                'If it states a constraint, move that to the declaration the constraint applies to.'
+            ),
+            fix=Fix.rewrite(),
+        )
+
+
+class DocCommentFormRule:
+    def __init__(self, conventions: LanguageConventions) -> None:
+        self._conventions = conventions
+        self.meta = DOC_COMMENT_FORM
+
+    def check(self, block: CommentBlock, context: RuleContext) -> typing.Iterable[Diagnostic]:
+        if not block.attaches_to_public_symbol or block.form is CommentForm.DOC:
+            return
+        if block.placement is not CommentPlacement.LEADING_DECLARATION:
+            return
+        marker = self._conventions.doc_form_marker
+        name = block.attachment.name if block.attachment else 'the symbol'
+        yield Diagnostic(
+            rule_id=self.meta.rule_id,
+            range=block.range,
+            message=(
+                f'{name} is public but documented with a plain comment. '
+                f'Move the text into a {marker} doc comment so tooling renders it on hover.'
+            ),
+            fix=Fix.rewrite(),
+        )
+
+
+class NoSignatureRestatingRule:
+    def __init__(self, conventions: LanguageConventions) -> None:
+        self._conventions = conventions
+        self.meta = NO_SIGNATURE_RESTATING
+
+    def check(self, block: CommentBlock, context: RuleContext) -> typing.Iterable[Diagnostic]:
+        if block.form is not CommentForm.DOC:
+            return
+        for line in block.lines:
+            tag = self._tag(line.payload)
+            if tag is None:
+                continue
+            yield Diagnostic(
+                rule_id=self.meta.rule_id,
+                range=block.range,
+                message=(
+                    f'The tag "{tag}" restates the signature, which the annotations already carry. '
+                    'Delete the tag and its block. '
+                    'If a parameter needs explaining, say why it matters in prose instead.'
+                ),
+                fix=Fix.rewrite(),
+            )
+            return
+
+    def _tag(self, payload: str) -> str | None:
+        stripped = payload.strip()
+        for tag in self._conventions.signature_tags:
+            if stripped.startswith(tag):
+                return tag
+        return None
+
+
+BLOCK_TOO_LONG = RuleMeta(
+    rule_id='block-too-long',
+    summary='A comment block long enough to restate the code has stopped earning its place.',
+    fix_kind=FixKind.REWRITE,
+)
+
+DEFAULT_LIMITS = {
+    'line': 4,
+    'doc-internal': 13,
+    'doc-public': 17,
+}
+
+
+class BlockTooLongRule:
+    meta = BLOCK_TOO_LONG
+
+    def check(self, block: CommentBlock, context: RuleContext) -> typing.Iterable[Diagnostic]:
+        group = self._group(block)
+        limit = context.settings(self.meta.rule_id).integer(group, DEFAULT_LIMITS[group])
+        if block.line_count <= limit:
+            return
+        yield Diagnostic(
+            rule_id=self.meta.rule_id,
+            range=block.range,
+            message=(
+                f'This comment runs to {block.line_count} lines against a {limit} line limit for {group} '
+                'comments. A comment earns its place by stating one constraint the code cannot show. '
+                'Cut it to that constraint, or move the explanation into a name.'
+            ),
+            fix=Fix.rewrite(),
+        )
+
+    def _group(self, block: CommentBlock) -> str:
+        if block.form is not CommentForm.DOC:
+            return 'line'
+        return 'doc-public' if block.attaches_to_public_symbol else 'doc-internal'

--- a/src/housestyle/presentation/cli.py
+++ b/src/housestyle/presentation/cli.py
@@ -9,6 +9,7 @@ from .. import __version__
 from ..application import Aggregator, CorpusStatistics, FixDocument, LintDocument, MeasureCorpus, RuleEngine
 from ..domain.document import Document
 from ..infrastructure import ALL_RULES, DEFAULT_CONFIG, DEFAULT_PARSER, EXTERNAL_LINTERS, PYTHON
+from . import docs as rule_docs
 from . import report as reporters
 
 
@@ -27,6 +28,9 @@ def _load(paths: tuple[pathlib.Path, ...]) -> tuple[Document, ...]:
             files.append(path)
     documents: list[Document] = []
     for file in files:
+        root = DEFAULT_CONFIG.root_for(str(file))
+        if DEFAULT_CONFIG.is_excluded(file, root, DEFAULT_CONFIG.excludes(str(file))):
+            continue
         try:
             text = file.read_text(encoding='utf-8')
         except (OSError, UnicodeDecodeError):
@@ -106,6 +110,17 @@ def stats(paths: list[pathlib.Path] = typer.Argument(..., help='Files or directo
     documents = _load(tuple(paths))
     _require(documents)
     typer.echo(_render(MeasureCorpus(DEFAULT_PARSER).run(documents)))
+
+
+@app.command()
+def rules(
+    write: pathlib.Path = typer.Option(None, '--write', help='Write the generated table to this path.'),
+) -> None:
+    rendered = rule_docs.render(ALL_RULES)
+    if write is None:
+        typer.echo(rendered, nl=False)
+        return
+    write.write_text(rendered, encoding='utf-8')
 
 
 @app.command()

--- a/src/housestyle/presentation/docs.py
+++ b/src/housestyle/presentation/docs.py
@@ -1,0 +1,21 @@
+from ..domain.diagnostic import RuleMeta
+from ..domain.rules import Rule
+
+
+HEADING = '# Rules'
+PREAMBLE = (
+    'Generated from `RuleMeta`. Edit the rule, not this file.\n\n'
+    'The fix kind states who resolves a finding. A mechanical kind is repaired without telling the author, '
+    'so only a rewrite reaches an agent.'
+)
+
+
+def render(rules: tuple[Rule, ...]) -> str:
+    ordered = sorted(rules, key=lambda rule: (rule.meta.fix_kind.value, rule.meta.rule_id))
+    lines = [HEADING, '', PREAMBLE, '', '| Rule | Fix kind | Summary |', '| --- | --- | --- |']
+    lines.extend(_row(rule.meta) for rule in ordered)
+    return '\n'.join(lines) + '\n'
+
+
+def _row(meta: RuleMeta) -> str:
+    return f'| `{meta.rule_id}` | {meta.fix_kind.value} | {meta.summary} |'

--- a/tests/test_rules_structural.py
+++ b/tests/test_rules_structural.py
@@ -1,0 +1,110 @@
+import pytest
+
+from housestyle.application import LintDocument, RuleEngine
+from housestyle.domain import Document, FixKind, RuleSet, RuleSettings
+from housestyle.infrastructure import ALL_RULES, DEFAULT_PARSER
+
+
+STRUCTURAL = frozenset({'no-file-header', 'doc-comment-form', 'no-signature-restating', 'block-too-long'})
+
+
+def lint(source: str, enabled: frozenset[str] = STRUCTURAL, width: int = 120, **settings: RuleSettings):
+    document = Document(uri='file:///a.py', text=source, language_id='python')
+    return LintDocument(DEFAULT_PARSER, RuleEngine(ALL_RULES)).run(
+        document, RuleSet(enabled=enabled, line_width=width, settings=settings)
+    )
+
+
+def ids(source: str, **kwargs) -> list[str]:
+    return [item.rule_id for item in lint(source, **kwargs).diagnostics]
+
+
+def test_a_banner_before_the_first_declaration_is_reported() -> None:
+    assert 'no-file-header' in ids('# a banner about this module\nimport os\n')
+
+
+def test_a_module_docstring_is_also_a_file_header() -> None:
+    assert 'no-file-header' in ids('"""A module banner."""\nimport os\n')
+
+
+def test_a_comment_attached_to_a_declaration_is_not_a_header() -> None:
+    assert 'no-file-header' not in ids('# documents the builder\ndef build():\n    pass\n')
+
+
+def test_a_public_symbol_documented_with_a_plain_comment_is_reported() -> None:
+    findings = lint('# documents the public builder\ndef build(x):\n    return x\n')
+    message = next(item.message for item in findings.diagnostics if item.rule_id == 'doc-comment-form')
+    assert 'build is public' in message
+    assert '"""' in message
+
+
+def test_an_internal_symbol_may_use_a_plain_comment() -> None:
+    assert 'doc-comment-form' not in ids('# documents the helper\ndef _helper(x):\n    return x\n')
+
+
+def test_a_public_symbol_with_a_docstring_is_fine() -> None:
+    assert 'doc-comment-form' not in ids('def build(x):\n    """Build it."""\n    return x\n')
+
+
+@pytest.mark.parametrize('tag', ['Args:', 'Returns:', 'Raises:', 'Yields:'])
+def test_a_signature_restating_tag_is_reported(tag: str) -> None:
+    source = f'def build(x):\n    """Build it.\n\n    {tag}\n        x: the thing\n    """\n'
+    assert 'no-signature-restating' in ids(source)
+
+
+def test_the_tag_is_quoted_in_the_message() -> None:
+    source = 'def build(x):\n    """Build it.\n\n    Args:\n        x: the thing\n    """\n'
+    message = next(item.message for item in lint(source).diagnostics if item.rule_id == 'no-signature-restating')
+    assert '"Args:"' in message
+
+
+def test_one_diagnostic_per_block_even_with_several_tags() -> None:
+    source = (
+        'def build(x):\n    """Build it.\n\n    Args:\n        x: a thing\n\n    Returns:\n        a thing\n    """\n'
+    )
+    assert ids(source).count('no-signature-restating') == 1
+
+
+def test_prose_that_merely_mentions_a_tag_word_is_fine() -> None:
+    assert 'no-signature-restating' not in ids('def build(x):\n    """Build it, returns quickly."""\n    return x\n')
+
+
+def test_a_plain_comment_is_not_checked_for_tags() -> None:
+    assert 'no-signature-restating' not in ids('def _f(x):\n    # Args: not a docstring\n    return x\n')
+
+
+def test_an_overlong_line_comment_is_reported() -> None:
+    body = ''.join(f'    # line {index}.\n' for index in range(6))
+    assert 'block-too-long' in ids(f'def f():\n{body}    pass\n')
+
+
+def test_a_short_line_comment_is_fine() -> None:
+    assert 'block-too-long' not in ids('def f():\n    # one.\n    # two.\n    pass\n')
+
+
+def test_the_limit_differs_between_public_and_internal_docstrings() -> None:
+    body = '\n'.join(f'    Sentence {index}.' for index in range(12))
+    public = f'def build():\n    """Summary.\n\n{body}\n    """\n'
+    internal = f'def _helper():\n    """Summary.\n\n{body}\n    """\n'
+
+    assert 'block-too-long' not in ids(public)
+    assert 'block-too-long' in ids(internal)
+
+
+def test_the_limits_are_configurable_per_group() -> None:
+    source = 'def f():\n    # one.\n    # two.\n    # three.\n    pass\n'
+    assert 'block-too-long' in ids(source, **{'block-too-long': RuleSettings(options={'line': 2})})
+
+
+def test_every_structural_finding_needs_an_author() -> None:
+    report = lint('# a banner\nimport os\n')
+    for item in report.diagnostics:
+        assert item.fix is not None
+        assert item.fix.kind is FixKind.REWRITE
+        assert item.needs_author
+
+
+@pytest.mark.parametrize('rule_id', sorted(STRUCTURAL))
+def test_each_rule_can_be_disabled_independently(rule_id: str) -> None:
+    source = '# a banner\ndef build(x):\n    """Build it.\n\n    Args:\n        x: a thing\n    """\n'
+    assert rule_id not in ids(source, enabled=STRUCTURAL - {rule_id})

--- a/tests/test_self_hosting.py
+++ b/tests/test_self_hosting.py
@@ -77,3 +77,43 @@ def test_the_project_config_is_readable_and_enables_every_rule() -> None:
     rules = DEFAULT_CONFIG.resolve(str(SOURCE_ROOT))
     assert rules.enabled == frozenset(rule.meta.rule_id for rule in ALL_RULES)
     assert rules.line_width == 120
+
+
+def test_the_generated_rule_reference_is_in_sync() -> None:
+    from housestyle.infrastructure import ALL_RULES
+    from housestyle.presentation import docs
+
+    reference = REPO_ROOT / 'docs' / 'rules.md'
+    assert reference.is_file(), 'run: housestyle rules --write docs/rules.md'
+    assert reference.read_text(encoding='utf-8') == docs.render(ALL_RULES)
+
+
+def test_every_rule_appears_in_the_reference() -> None:
+    from housestyle.infrastructure import ALL_RULES
+
+    reference = (REPO_ROOT / 'docs' / 'rules.md').read_text(encoding='utf-8')
+    missing = [rule.meta.rule_id for rule in ALL_RULES if f'`{rule.meta.rule_id}`' not in reference]
+    assert not missing, f'rules absent from the reference: {missing}'
+
+
+def test_the_repository_installs_its_own_hook() -> None:
+    import json
+
+    settings = json.loads((REPO_ROOT / '.claude' / 'settings.json').read_text(encoding='utf-8'))
+    commands = [
+        entry['command']
+        for group in settings['hooks']['PostToolUse']
+        for entry in group['hooks']
+        if entry.get('type') == 'command'
+    ]
+    assert any('housestyle-hook' in command for command in commands)
+
+
+def test_the_excluded_fixture_is_actually_excluded() -> None:
+    from housestyle.infrastructure import DEFAULT_CONFIG
+
+    fixture = REPO_ROOT / 'tests' / 'fixtures' / 'vale' / 'violations.py'
+    patterns = DEFAULT_CONFIG.excludes(str(fixture))
+    assert patterns, 'the project config must declare an exclude for deliberate fixtures'
+    assert DEFAULT_CONFIG.is_excluded(fixture, REPO_ROOT, patterns)
+    assert not DEFAULT_CONFIG.is_excluded(REPO_ROOT / 'src' / 'housestyle' / 'domain' / 'prose.py', REPO_ROOT, patterns)


### PR DESCRIPTION
Completes M5 and makes self-hosting real.

## The structural tier

The third and last rule category. Logic is shared, bindings come from `LanguageConventions`.

| Rule | Fires on |
| --- | --- |
| `no-file-header` | any comment before the first declaration, including a module docstring |
| `doc-comment-form` | a public symbol documented with a plain comment instead of the language's doc form |
| `no-signature-restating` | `Args:` / `Returns:` / `Raises:` / `Yields:`, one finding per block |
| `block-too-long` | a block past the limit for its group |

`no-signature-restating` reads its tag set from the profile, so it is Python's `Args:` here and will be `@param` once TypeScript lands, with no rule change.

## Limits from the corpus, not from feel

```
group              n   med  p95  p99  max     limit
line/inline-body  28    1    3    4    4        4
doc/internal      57    5    9   13   14       13
doc/public       128    4   12   17   38       17
```

All four rules together add **four findings across 65 files**.

## Four self-hosting gaps, all closed

| Gap | Now |
| --- | --- |
| `tests/` was never checked | CI runs `housestyle check src/ tests/` |
| the deliberate Vale fixture would fail it | excluded through a new `exclude` config key, not by narrowing the command |
| no generated rule reference | `housestyle rules --write docs/rules.md`, with a test that fails when it drifts |
| **the repo did not run its own hook** | `.claude/settings.json` installs `housestyle-hook` |

The last one deserves saying plainly: a tool built so that agents cannot forget a convention had no business going without the mechanism itself.

Everything green: housestyle, Vale, ruff, basedpyright, 326 tests.

Closes #15
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)