### PR TITLE
Separate the hook reporter from the interactive one

### DIFF
--- a/src/housestyle/presentation/cli.py
+++ b/src/housestyle/presentation/cli.py
@@ -16,7 +16,7 @@ from . import report as reporters
 app = typer.Typer(add_completion=False, help='A linter and formatter for the prose inside code comments.')
 
 PERCENTILES = (0.5, 0.75, 0.9, 0.95, 0.99)
-FORMATTERS = {'human': reporters.human, 'agent': reporters.agent, 'json': reporters.as_json}
+FORMATTERS = {'human': reporters.human, 'agent': reporters.agent_verbose, 'json': reporters.as_json}
 
 
 def _load(paths: tuple[pathlib.Path, ...]) -> tuple[Document, ...]:

--- a/src/housestyle/presentation/report.py
+++ b/src/housestyle/presentation/report.py
@@ -18,6 +18,23 @@ def human(document: Document, report: Report) -> str:
 def agent(document: Document, report: Report) -> str:
     if not report.needing_author:
         return ''
+    return _rewrite_brief(document, report)
+
+
+def agent_verbose(document: Document, report: Report) -> str:
+    if report.needing_author:
+        return _rewrite_brief(document, report)
+    if report.mechanical:
+        count = len(report.mechanical)
+        return (
+            f'Nothing needs rewriting in {_path(document)}. '
+            f'{count} finding{"s" if count != 1 else ""} can be repaired mechanically, '
+            'so run fix --write rather than editing by hand.'
+        )
+    return f'No findings in {_path(document)}.'
+
+
+def _rewrite_brief(document: Document, report: Report) -> str:
     lines = [
         f'{len(report.needing_author)} comment findings need rewriting in {_path(document)}.',
         'Each states the fix. Apply it in place, do not add a suppression comment.',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,3 +126,31 @@ def test_the_json_format_encodes_ranges_and_fix_kind(
     payload = json.loads(capsys.readouterr().out)
     assert payload['diagnostics'][0]['fixKind'] == 'reflow'
     assert payload['diagnostics'][0]['mechanical'] is True
+
+
+def test_the_agent_format_says_so_when_only_mechanical_findings_exist(
+    tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / 'a.py'
+    target.write_text(
+        'def f():\n    # cap the size so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n',
+        encoding='utf-8',
+    )
+    (tmp_path / 'housestyle.toml').write_text('[housestyle]\nline-width = 60\n', encoding='utf-8')
+
+    with pytest.raises(SystemExit):
+        app(['check', str(target), '--output', 'agent'])
+    output = capsys.readouterr().out
+    assert 'Nothing needs rewriting' in output
+    assert 'repaired mechanically' in output
+
+
+def test_the_agent_format_says_so_when_nothing_is_wrong(
+    tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / 'a.py'
+    target.write_text('def f():\n    # short and fine.\n    pass\n', encoding='utf-8')
+
+    with pytest.raises(SystemExit):
+        app(['check', str(target), '--output', 'agent'])
+    assert 'No findings' in capsys.readouterr().out

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -121,3 +121,10 @@ def test_the_entry_point_blocks_on_a_rewrite_finding(tmp_path: pathlib.Path) -> 
     )
     assert result.returncode == 2
     assert 'unbreakable-sentence' in result.stderr
+
+
+def test_the_hook_stays_silent_on_mechanical_findings_even_now(tmp_path: pathlib.Path) -> None:
+    target = seed(tmp_path, MIS_WRAPPED)
+    outcome = hook.run(payload(target))
+    assert outcome.stderr == '', 'the hook must never narrate a repair it made silently'
+    assert outcome.exit_code == 0


### PR DESCRIPTION
Found by following my own reading guide, which is the point of writing one.

`housestyle check --output=agent` printed **nothing** on a file whose only finding was mechanical. Silence there is correct for the hook, where every surfaced message costs agent attention. It is wrong for a person who explicitly asked for that view and now cannot tell an empty result from a clean one.

The two callers wanted different things from one function.

| State | Before | After |
| --- | --- | --- |
| something needs rewriting | the findings | unchanged |
| only mechanical findings | *nothing* | `Nothing needs rewriting in a.py. 1 finding can be repaired mechanically, so run fix --write rather than editing by hand.` |
| clean | *nothing* | `No findings in a.py.` |

`check` takes the verbose variant, the hook keeps the silent one. A test asserts the hook still never narrates a repair it made silently, because that silence is a design property rather than an accident.

329 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)