### PR TITLE
Resolve names through decorator wrappers

### DIFF
--- a/src/housestyle/domain/comment.py
+++ b/src/housestyle/domain/comment.py
@@ -69,7 +69,12 @@ class CommentGroup:
 
     def __post_init__(self) -> None:
         if not self.lines:
-            raise ValueError('A comment block needs at least one line')
+            raise ValueError('A comment group needs at least one line')
+        if self.attachment is not None and self.placement is not CommentPlacement.LEADING_DECLARATION:
+            raise ValueError(
+                f'Only a leading declaration comment documents a symbol, '
+                f'but a {self.placement.value} comment carries {self.attachment.name!r}'
+            )
 
     @property
     def line_count(self) -> int:

--- a/src/housestyle/infrastructure/parser.py
+++ b/src/housestyle/infrastructure/parser.py
@@ -165,12 +165,25 @@ class TreeSitterParser:
         target = self._owning_definition(profile, node) if is_doc else self._next_definition(profile, node)
         if target is None:
             return None
-        named = target.child_by_field_name('name')
+        declared = self._named_declaration(profile, target)
+        if declared is None:
+            return None
+        named = declared.child_by_field_name('name')
         if named is None or named.text is None:
             return None
         name = named.text.decode('utf-8')
         return SymbolRef(
             name=name,
-            kind=profile.symbol_kind(target.type),
+            kind=profile.symbol_kind(declared.type),
             visibility=profile.visibility_of(name),
         )
+
+    def _named_declaration(self, profile: LanguageProfile, node: Node) -> Node | None:
+        if node.child_by_field_name('name') is not None:
+            return node
+        for child in node.named_children:
+            if profile.role_of(child.type) is NodeRole.DEFINITION:
+                found = self._named_declaration(profile, child)
+                if found is not None:
+                    return found
+        return None

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -91,13 +91,31 @@ def test_with_payloads_rejects_an_empty_result() -> None:
         group('one').with_texts(())
 
 
-def test_public_attachment_is_reported() -> None:
-    public = group('doc', attachment=SymbolRef('buildProposal', SymbolKind.FUNCTION, Visibility.PUBLIC))
-    internal = group('doc', attachment=SymbolRef('_helper', SymbolKind.FUNCTION, Visibility.INTERNAL))
+def documented(name: str, visibility: Visibility) -> CommentGroup:
+    return group(
+        'doc',
+        placement=CommentPlacement.LEADING_DECLARATION,
+        attachment=SymbolRef(name, SymbolKind.FUNCTION, visibility),
+    )
 
-    assert public.attaches_to_public_symbol
-    assert not internal.attaches_to_public_symbol
+
+def test_public_attachment_is_reported() -> None:
+    assert documented('buildProposal', Visibility.PUBLIC).attaches_to_public_symbol
+    assert not documented('_helper', Visibility.INTERNAL).attaches_to_public_symbol
     assert not group('doc').attaches_to_public_symbol
+
+
+@pytest.mark.parametrize(
+    'placement',
+    [CommentPlacement.FILE_HEADER, CommentPlacement.INLINE_BODY, CommentPlacement.TRAILING],
+)
+def test_only_a_leading_declaration_may_document_a_symbol(placement: CommentPlacement) -> None:
+    with pytest.raises(ValueError, match='Only a leading declaration'):
+        group(
+            'doc',
+            placement=placement,
+            attachment=SymbolRef('build', SymbolKind.FUNCTION, Visibility.PUBLIC),
+        )
 
 
 def test_as_edit_targets_the_block_range() -> None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -169,3 +169,47 @@ def test_the_profile_satisfies_the_language_profile_port() -> None:
     assert profile.language_id == 'python'
     assert '.py' in profile.extensions
     assert parser.supports('python')
+
+
+@pytest.mark.parametrize(
+    ('source', 'expected'),
+    [
+        ('# note\n@cache\ndef build():\n    pass\n', 'build'),
+        ('# note\n@a\n@b\ndef build():\n    pass\n', 'build'),
+        ('# note\n@app.command(name="x")\ndef build():\n    pass\n', 'build'),
+        ('# note\n@dataclass\nclass Widget:\n    pass\n', 'Widget'),
+        ('def outer():\n    """Doc."""\n', 'outer'),
+    ],
+)
+def test_a_decorated_declaration_still_resolves_its_name(source: str, expected: str) -> None:
+    block = parse(source)[0]
+    assert block.attachment is not None
+    assert block.attachment.name == expected
+
+
+def test_a_decorated_class_is_still_a_class() -> None:
+    block = parse('# note\n@dataclass\nclass Widget:\n    pass\n')[0]
+    assert block.attachment is not None
+    assert block.attachment.kind is SymbolKind.CLASS
+
+
+def test_a_decorated_private_function_is_still_internal() -> None:
+    block = parse('# note\n@cache\ndef _helper():\n    pass\n')[0]
+    assert block.attachment is not None
+    assert block.attachment.visibility is Visibility.INTERNAL
+
+
+@pytest.mark.parametrize(
+    'source',
+    [
+        '# note\ndef build():\n    pass\n',
+        '# note\n@cache\ndef build():\n    pass\n',
+        '# note\nclass Widget:\n    pass\n',
+        '# note\n@dataclass\nclass Widget:\n    pass\n',
+        '# note\nasync def build():\n    pass\n',
+    ],
+)
+def test_a_leading_declaration_comment_always_names_what_it_documents(source: str) -> None:
+    block = parse(source)[0]
+    assert block.placement is CommentPlacement.LEADING_DECLARATION
+    assert block.attachment is not None, 'leading-declaration without an attachment silently disables rules'

--- a/tests/test_rules_structural.py
+++ b/tests/test_rules_structural.py
@@ -108,3 +108,12 @@ def test_every_structural_finding_needs_an_author() -> None:
 def test_each_rule_can_be_disabled_independently(rule_id: str) -> None:
     source = '# a banner\ndef build(x):\n    """Build it.\n\n    Args:\n        x: a thing\n    """\n'
     assert rule_id not in ids(source, enabled=STRUCTURAL - {rule_id})
+
+
+@pytest.mark.parametrize(
+    'decorator',
+    ['', '@cache\n', '@a\n@b\n', '@app.command(name="x")\n'],
+)
+def test_doc_comment_form_survives_decorators(decorator: str) -> None:
+    source = f'# documents the public builder\n{decorator}def build(x):\n    return x\n'
+    assert 'doc-comment-form' in ids(source)


### PR DESCRIPTION
Found by a reader asking whether `leading-declaration` always implies an attachment. It did not, and the gap was wide.

## The bug

Tree-sitter wraps a decorated declaration in a node that carries no name of its own:

```
decorated_definition          <- captured here, no name field
├── decorator  @cache
└── function_definition       <- the name lives here
    └── identifier  build
```

Attachment resolution stopped at the wrapper and returned `None`.

## Why it mattered more than a missing field

`doc-comment-form` asks whether a comment documents a public symbol, which needs the attachment. So:

```
# documents the public builder
def build(x): ...          ->  doc-comment-form fires

# documents the public builder
@cache
def build(x): ...          ->  nothing at all
```

**A rule that silently stops applying is the worst failure mode available**, because nothing reports it. Decorators are everywhere in Python, so this was not an edge case.

The symbol kind was wrong for the same reason. A decorated class reported as a function.

## The fix

Attachment resolution descends through wrapper nodes to the declaration that actually names something. A parametrised test pins the invariant across bare, single, stacked, and called decorators for both functions and classes:

> a `leading-declaration` comment must always name what it documents

345 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)