### PR TITLE
Name rules after the problem they report

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ The hook reads the tool payload on stdin, repairs every mechanical finding in pl
 
 Silence on repaired findings is deliberate. Each surfaced message costs agent attention, and attention is the scarce resource this tool exists to protect.
 
+## Configuration
+
+Settings come from `housestyle.toml`, or from `[tool.housestyle]` in `pyproject.toml`, whichever is found first walking upward from the file being checked. A dedicated file wins over `pyproject.toml` in the same directory.
+
+```toml
+[housestyle]
+line-width = 120
+exclude = ["tests/fixtures/**"]
+
+[rules]
+mid-clause-break = "error"
+block-too-long = { severity = "warning", line = 3, doc-public = 20 }
+```
+
+Rule names describe the problem they report, following the convention ruff uses. Every rule is listed in `docs/rules.md`, which is generated from the rules themselves.
+
 ## Frontends
 
 One pure core, `lint(text, path, config) -> Diagnostic[]`, behind several thin adapters.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -6,11 +6,11 @@ The fix kind states who resolves a finding. A mechanical kind is repaired withou
 
 | Rule | Fix kind | Summary |
 | --- | --- | --- |
-| `line-width` | reflow | A physical comment line must fit the configured width, counting indent and delimiter. |
-| `wrap-point` | reflow | A comment block must be laid out one sentence per line, splitting only at commas. |
+| `line-too-long` | reflow | A physical comment line must fit the configured width, counting indent and delimiter. |
+| `mid-clause-break` | reflow | A comment block must be laid out one sentence per line, splitting only at commas. |
 | `block-too-long` | rewrite | A comment block long enough to restate the code has stopped earning its place. |
-| `doc-comment-form` | rewrite | A public symbol must be documented in the doc comment form its language renders. |
-| `no-file-header` | rewrite | A file must not open with a banner comment before its first declaration. |
-| `no-signature-restating` | rewrite | A doc comment must not restate what the type signature already carries. |
+| `file-header-comment` | rewrite | A file must not open with a banner comment before its first declaration. |
+| `plain-comment-on-public` | rewrite | A public symbol must be documented in the doc comment form its language renders. |
+| `signature-restating-tag` | rewrite | A doc comment must not restate what the type signature already carries. |
 | `stub-fragment` | rewrite | A sentence forced to break must not leave a stub of a line behind. |
 | `unbreakable-sentence` | rewrite | A sentence over the width must carry a comma so it has somewhere legal to break. |

--- a/housestyle.toml
+++ b/housestyle.toml
@@ -3,11 +3,11 @@ line-width = 120
 exclude = ["tests/fixtures/**", "examples/probe.py"]
 
 [rules]
-wrap-point = "error"
-line-width = "error"
+mid-clause-break = "error"
+line-too-long = "error"
 stub-fragment = "error"
 unbreakable-sentence = "error"
-no-file-header = "error"
-doc-comment-form = "error"
-no-signature-restating = "error"
+file-header-comment = "error"
+plain-comment-on-public = "error"
+signature-restating-tag = "error"
 block-too-long = "error"

--- a/src/housestyle/infrastructure/config.py
+++ b/src/housestyle/infrastructure/config.py
@@ -7,6 +7,7 @@ from .schema import ConfigFile, RuleTable
 
 
 CONFIG_NAME = 'housestyle.toml'
+PYPROJECT_NAME = 'pyproject.toml'
 DEFAULT_WIDTH = 120
 
 
@@ -46,15 +47,39 @@ class TomlConfigSource:
             raw_table = tomllib.loads(config_path.read_text(encoding='utf-8'))
         except (OSError, tomllib.TOMLDecodeError):
             return None
+        if config_path.name == PYPROJECT_NAME:
+            raw_table = self._reshape_pyproject(raw_table)
+            if raw_table is None:
+                return None
         return ConfigFile.parse(raw_table)
+
+    def _reshape_pyproject(self, raw_table: dict[str, object]) -> dict[str, object] | None:
+        tools = raw_table.get('tool')
+        section = tools.get('housestyle') if isinstance(tools, dict) else None
+        if not isinstance(section, dict):
+            return None
+        return {
+            'housestyle': {key: value for key, value in section.items() if key != 'rules'},
+            'rules': section.get('rules', {}),
+        }
 
     def _locate(self, start: pathlib.Path) -> pathlib.Path | None:
         base = start if start.is_dir() else start.parent
         for candidate in (base.resolve(), *base.resolve().parents):
-            config_path = candidate / CONFIG_NAME
-            if config_path.is_file():
-                return config_path
+            for name in (CONFIG_NAME, PYPROJECT_NAME):
+                config_path = candidate / name
+                if config_path.is_file() and self._carries_settings(config_path):
+                    return config_path
         return None
+
+    def _carries_settings(self, config_path: pathlib.Path) -> bool:
+        if config_path.name != PYPROJECT_NAME:
+            return True
+        try:
+            tools = tomllib.loads(config_path.read_text(encoding='utf-8')).get('tool')
+        except (OSError, tomllib.TOMLDecodeError):
+            return False
+        return isinstance(tools, dict) and 'housestyle' in tools
 
     def _to_rule_set(self, config_file: ConfigFile) -> RuleSet:
         enabled = set(self._available)

--- a/src/housestyle/infrastructure/rules/__init__.py
+++ b/src/housestyle/infrastructure/rules/__init__.py
@@ -1,15 +1,15 @@
 from ..languages import PYTHON
-from .layout import LineWidthRule, WrapPointRule
+from .layout import LineTooLongRule, MidClauseBreakRule
 from .rewrite import StubFragmentRule, UnbreakableSentenceRule
-from .structural import BlockTooLongRule, DocCommentFormRule, NoFileHeaderRule, NoSignatureRestatingRule
+from .structural import BlockTooLongRule, FileHeaderCommentRule, PlainCommentOnPublicRule, SignatureRestatingTagRule
 
 
-LAYOUT_RULES = (WrapPointRule(), LineWidthRule())
+LAYOUT_RULES = (MidClauseBreakRule(), LineTooLongRule())
 REWRITE_RULES = (StubFragmentRule(), UnbreakableSentenceRule())
 STRUCTURAL_RULES = (
-    NoFileHeaderRule(),
-    DocCommentFormRule(PYTHON),
-    NoSignatureRestatingRule(PYTHON),
+    FileHeaderCommentRule(),
+    PlainCommentOnPublicRule(PYTHON),
+    SignatureRestatingTagRule(PYTHON),
     BlockTooLongRule(),
 )
 ALL_RULES = LAYOUT_RULES + REWRITE_RULES + STRUCTURAL_RULES
@@ -20,11 +20,11 @@ __all__ = [
     'REWRITE_RULES',
     'STRUCTURAL_RULES',
     'BlockTooLongRule',
-    'DocCommentFormRule',
-    'LineWidthRule',
-    'NoFileHeaderRule',
-    'NoSignatureRestatingRule',
+    'FileHeaderCommentRule',
+    'LineTooLongRule',
+    'MidClauseBreakRule',
+    'PlainCommentOnPublicRule',
+    'SignatureRestatingTagRule',
     'StubFragmentRule',
     'UnbreakableSentenceRule',
-    'WrapPointRule',
 ]

--- a/src/housestyle/infrastructure/rules/layout.py
+++ b/src/housestyle/infrastructure/rules/layout.py
@@ -5,21 +5,21 @@ from ...domain.diagnostic import Diagnostic, Fix, FixKind, RuleMeta
 from ...domain.rules import RuleContext
 
 
-WRAP_POINT = RuleMeta(
-    rule_id='wrap-point',
+MID_CLAUSE_BREAK = RuleMeta(
+    rule_id='mid-clause-break',
     summary='A comment block must be laid out one sentence per line, splitting only at commas.',
     fix_kind=FixKind.REFLOW,
 )
 
-LINE_WIDTH = RuleMeta(
-    rule_id='line-width',
+LINE_TOO_LONG = RuleMeta(
+    rule_id='line-too-long',
     summary='A physical comment line must fit the configured width, counting indent and delimiter.',
     fix_kind=FixKind.REFLOW,
 )
 
 
-class WrapPointRule:
-    meta = WRAP_POINT
+class MidClauseBreakRule:
+    meta = MID_CLAUSE_BREAK
 
     def check(self, block: CommentGroup, context: RuleContext) -> typing.Iterable[Diagnostic]:
         reflowed = block.reflow(context.line_width)
@@ -36,8 +36,8 @@ class WrapPointRule:
         )
 
 
-class LineWidthRule:
-    meta = LINE_WIDTH
+class LineTooLongRule:
+    meta = LINE_TOO_LONG
 
     def check(self, block: CommentGroup, context: RuleContext) -> typing.Iterable[Diagnostic]:
         width = context.line_width

--- a/src/housestyle/infrastructure/rules/structural.py
+++ b/src/housestyle/infrastructure/rules/structural.py
@@ -6,27 +6,27 @@ from ...domain.rules import RuleContext
 from ..languages.base import LanguageConventions
 
 
-NO_FILE_HEADER = RuleMeta(
-    rule_id='no-file-header',
+FILE_HEADER_COMMENT = RuleMeta(
+    rule_id='file-header-comment',
     summary='A file must not open with a banner comment before its first declaration.',
     fix_kind=FixKind.REWRITE,
 )
 
-DOC_COMMENT_FORM = RuleMeta(
-    rule_id='doc-comment-form',
+PLAIN_COMMENT_ON_PUBLIC = RuleMeta(
+    rule_id='plain-comment-on-public',
     summary='A public symbol must be documented in the doc comment form its language renders.',
     fix_kind=FixKind.REWRITE,
 )
 
-NO_SIGNATURE_RESTATING = RuleMeta(
-    rule_id='no-signature-restating',
+SIGNATURE_RESTATING_TAG = RuleMeta(
+    rule_id='signature-restating-tag',
     summary='A doc comment must not restate what the type signature already carries.',
     fix_kind=FixKind.REWRITE,
 )
 
 
-class NoFileHeaderRule:
-    meta = NO_FILE_HEADER
+class FileHeaderCommentRule:
+    meta = FILE_HEADER_COMMENT
 
     def check(self, block: CommentGroup, context: RuleContext) -> typing.Iterable[Diagnostic]:
         if block.placement is not CommentPlacement.FILE_HEADER:
@@ -43,10 +43,10 @@ class NoFileHeaderRule:
         )
 
 
-class DocCommentFormRule:
+class PlainCommentOnPublicRule:
     def __init__(self, conventions: LanguageConventions) -> None:
         self._conventions = conventions
-        self.meta = DOC_COMMENT_FORM
+        self.meta = PLAIN_COMMENT_ON_PUBLIC
 
     def check(self, block: CommentGroup, context: RuleContext) -> typing.Iterable[Diagnostic]:
         if not block.attaches_to_public_symbol or block.form is CommentForm.DOC:
@@ -66,10 +66,10 @@ class DocCommentFormRule:
         )
 
 
-class NoSignatureRestatingRule:
+class SignatureRestatingTagRule:
     def __init__(self, conventions: LanguageConventions) -> None:
         self._conventions = conventions
-        self.meta = NO_SIGNATURE_RESTATING
+        self.meta = SIGNATURE_RESTATING_TAG
 
     def check(self, block: CommentGroup, context: RuleContext) -> typing.Iterable[Diagnostic]:
         if block.form is not CommentForm.DOC:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,7 +45,7 @@ def test_check_reports_findings_and_exits_non_zero(tmp_path: pathlib.Path, capsy
     with pytest.raises(SystemExit) as exit_info:
         app(['check', str(target)])
     assert exit_info.value.code == 1
-    assert 'wrap-point' in capsys.readouterr().out
+    assert 'mid-clause-break' in capsys.readouterr().out
 
 
 def test_check_on_clean_input_exits_zero(tmp_path: pathlib.Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ from housestyle.domain import Severity
 from housestyle.infrastructure import CONFIG_NAME, TomlConfigSource
 
 
-AVAILABLE = ('wrap-point', 'line-width', 'stub-fragment')
+AVAILABLE = ('mid-clause-break', 'line-too-long', 'stub-fragment')
 
 
 def source() -> TomlConfigSource:
@@ -32,16 +32,16 @@ def test_configuration_is_found_by_walking_upward(tmp_path: pathlib.Path) -> Non
 
 
 def test_a_rule_can_be_switched_off(tmp_path: pathlib.Path) -> None:
-    target = write(tmp_path, '[rules]\nwrap-point = false\n')
+    target = write(tmp_path, '[rules]\nmid-clause-break = false\n')
     rules = source().resolve(str(target))
-    assert not rules.is_enabled('wrap-point')
-    assert rules.is_enabled('line-width')
+    assert not rules.is_enabled('mid-clause-break')
+    assert rules.is_enabled('line-too-long')
 
 
 def test_a_severity_string_is_honoured(tmp_path: pathlib.Path) -> None:
-    target = write(tmp_path, '[rules]\nwrap-point = "warning"\n')
+    target = write(tmp_path, '[rules]\nmid-clause-break = "warning"\n')
     rules = source().resolve(str(target))
-    assert rules.settings_for('wrap-point').severity is Severity.WARNING
+    assert rules.settings_for('mid-clause-break').severity is Severity.WARNING
 
 
 def test_a_table_carries_severity_and_options(tmp_path: pathlib.Path) -> None:
@@ -59,3 +59,42 @@ def test_an_unknown_rule_is_ignored(tmp_path: pathlib.Path) -> None:
 def test_a_nonsense_width_falls_back_to_the_default(tmp_path: pathlib.Path) -> None:
     target = write(tmp_path, '[housestyle]\nline-width = "wide"\n')
     assert source().resolve(str(target)).line_width == 120
+
+
+PYPROJECT = 'pyproject.toml'
+
+
+def write_pyproject(directory: pathlib.Path, body: str) -> pathlib.Path:
+    (directory / PYPROJECT).write_text(body, encoding='utf-8')
+    target = directory / 'module.py'
+    target.write_text('# note\n', encoding='utf-8')
+    return target
+
+
+def test_settings_are_read_from_pyproject(tmp_path: pathlib.Path) -> None:
+    target = write_pyproject(tmp_path, '[project]\nname = "x"\n\n[tool.housestyle]\nline-width = 96\n')
+    assert source().resolve(str(target)).line_width == 96
+
+
+def test_rules_nest_under_the_tool_table_in_pyproject(tmp_path: pathlib.Path) -> None:
+    body = '[tool.housestyle]\nline-width = 96\n\n[tool.housestyle.rules]\nmid-clause-break = false\n'
+    rules = source().resolve(str(write_pyproject(tmp_path, body)))
+
+    assert not rules.is_enabled('mid-clause-break')
+    assert rules.is_enabled('line-too-long')
+
+
+def test_excludes_are_read_from_pyproject(tmp_path: pathlib.Path) -> None:
+    body = '[tool.housestyle]\nexclude = ["build/**"]\n'
+    assert source().excludes(str(write_pyproject(tmp_path, body))) == ('build/**',)
+
+
+def test_a_pyproject_without_our_table_is_ignored(tmp_path: pathlib.Path) -> None:
+    target = write_pyproject(tmp_path, '[project]\nname = "x"\n\n[tool.ruff]\nline-length = 88\n')
+    assert source().resolve(str(target)).line_width == 120
+
+
+def test_a_dedicated_file_wins_over_pyproject(tmp_path: pathlib.Path) -> None:
+    (tmp_path / PYPROJECT).write_text('[tool.housestyle]\nline-width = 96\n', encoding='utf-8')
+    target = write(tmp_path, '[housestyle]\nline-width = 70\n')
+    assert source().resolve(str(target)).line_width == 70

--- a/tests/test_diagnostic.py
+++ b/tests/test_diagnostic.py
@@ -7,7 +7,7 @@ def edit(start: int = 0, end: int = 1, new_text: str = 'x') -> TextEdit:
     return TextEdit(SourceRange(start, end), new_text)
 
 
-def diagnostic(rule_id: str = 'wrap-point', start: int = 0, fix: Fix | None = None) -> Diagnostic:
+def diagnostic(rule_id: str = 'mid-clause-break', start: int = 0, fix: Fix | None = None) -> Diagnostic:
     return Diagnostic(rule_id=rule_id, range=SourceRange(start, start + 1), message='something', fix=fix)
 
 
@@ -55,13 +55,13 @@ def test_a_rule_needs_an_id() -> None:
 
 
 def test_rule_meta_defaults_to_error() -> None:
-    meta = RuleMeta(rule_id='wrap-point', summary='s', fix_kind=FixKind.REFLOW)
+    meta = RuleMeta(rule_id='mid-clause-break', summary='s', fix_kind=FixKind.REFLOW)
     assert meta.default_severity is Severity.ERROR
     assert meta.source == 'housestyle'
 
 
 def test_report_partitions_by_who_can_fix() -> None:
-    mechanical = diagnostic('line-width', 0, Fix.reflow(edit()))
+    mechanical = diagnostic('line-too-long', 0, Fix.reflow(edit()))
     authored = diagnostic('stub-fragment', 5, Fix.rewrite())
     report = Report((mechanical, authored))
 

--- a/tests/test_fixing.py
+++ b/tests/test_fixing.py
@@ -16,7 +16,7 @@ from housestyle.domain import (
 from housestyle.infrastructure import ALL_RULES, DEFAULT_PARSER
 
 
-LAYOUT = frozenset({'wrap-point', 'line-width', 'stub-fragment', 'unbreakable-sentence'})
+LAYOUT = frozenset({'mid-clause-break', 'line-too-long', 'stub-fragment', 'unbreakable-sentence'})
 
 
 def fixer(rules=ALL_RULES, max_rounds: int = 10) -> FixDocument:

--- a/tests/test_rules_layout.py
+++ b/tests/test_rules_layout.py
@@ -5,7 +5,7 @@ from housestyle.domain import Document, FixKind, RuleSet, apply_edits
 from housestyle.infrastructure import DEFAULT_PARSER, LAYOUT_RULES
 
 
-ALL_LAYOUT = frozenset({'wrap-point', 'line-width'})
+ALL_LAYOUT = frozenset({'mid-clause-break', 'line-too-long'})
 
 
 def lint(source: str, width: int = 60, enabled: frozenset[str] = ALL_LAYOUT):
@@ -28,7 +28,7 @@ def test_already_correct_layout_is_clean() -> None:
 def test_a_mid_clause_break_is_reported_and_reflowed() -> None:
     source = 'def f():\n    # cap the size to the limit so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n'
     report = lint(source)
-    assert 'wrap-point' in [item.rule_id for item in report.diagnostics]
+    assert 'mid-clause-break' in [item.rule_id for item in report.diagnostics]
     assert '# cap the size to the limit so the mmap does not blow past it,\n' in fixed(source)
 
 
@@ -56,19 +56,19 @@ def test_line_width_counts_indent_and_marker() -> None:
     deep = f'def a():\n    def b():\n        def c():\n            # {text}\n            pass\n'
 
     width = len(f'    # {text}') + 1
-    assert 'line-width' not in [item.rule_id for item in lint(shallow, width=width).diagnostics]
-    assert 'line-width' in [item.rule_id for item in lint(deep, width=width).diagnostics]
+    assert 'line-too-long' not in [item.rule_id for item in lint(shallow, width=width).diagnostics]
+    assert 'line-too-long' in [item.rule_id for item in lint(deep, width=width).diagnostics]
 
 
 def test_line_width_stays_silent_when_the_block_already_fits() -> None:
     source = 'def f():\n    # short.\n    pass\n'
-    assert 'line-width' not in [item.rule_id for item in lint(source, width=80).diagnostics]
+    assert 'line-too-long' not in [item.rule_id for item in lint(source, width=80).diagnostics]
 
 
 def test_line_width_stays_silent_when_reflow_cannot_help() -> None:
     long_word = 'a' * 90
     source = f'def f():\n    # {long_word}.\n    pass\n'
-    assert 'line-width' not in [item.rule_id for item in lint(source, width=40).diagnostics]
+    assert 'line-too-long' not in [item.rule_id for item in lint(source, width=40).diagnostics]
 
 
 def test_layout_fixes_are_reflow_kind() -> None:

--- a/tests/test_rules_structural.py
+++ b/tests/test_rules_structural.py
@@ -5,7 +5,7 @@ from housestyle.domain import Document, FixKind, RuleSet, RuleSettings
 from housestyle.infrastructure import ALL_RULES, DEFAULT_PARSER
 
 
-STRUCTURAL = frozenset({'no-file-header', 'doc-comment-form', 'no-signature-restating', 'block-too-long'})
+STRUCTURAL = frozenset({'file-header-comment', 'plain-comment-on-public', 'signature-restating-tag', 'block-too-long'})
 
 
 def lint(source: str, enabled: frozenset[str] = STRUCTURAL, width: int = 120, **settings: RuleSettings):
@@ -20,41 +20,41 @@ def ids(source: str, **kwargs) -> list[str]:
 
 
 def test_a_banner_before_the_first_declaration_is_reported() -> None:
-    assert 'no-file-header' in ids('# a banner about this module\nimport os\n')
+    assert 'file-header-comment' in ids('# a banner about this module\nimport os\n')
 
 
 def test_a_module_docstring_is_also_a_file_header() -> None:
-    assert 'no-file-header' in ids('"""A module banner."""\nimport os\n')
+    assert 'file-header-comment' in ids('"""A module banner."""\nimport os\n')
 
 
 def test_a_comment_attached_to_a_declaration_is_not_a_header() -> None:
-    assert 'no-file-header' not in ids('# documents the builder\ndef build():\n    pass\n')
+    assert 'file-header-comment' not in ids('# documents the builder\ndef build():\n    pass\n')
 
 
 def test_a_public_symbol_documented_with_a_plain_comment_is_reported() -> None:
     findings = lint('# documents the public builder\ndef build(x):\n    return x\n')
-    message = next(item.message for item in findings.diagnostics if item.rule_id == 'doc-comment-form')
+    message = next(item.message for item in findings.diagnostics if item.rule_id == 'plain-comment-on-public')
     assert 'build is public' in message
     assert '"""' in message
 
 
 def test_an_internal_symbol_may_use_a_plain_comment() -> None:
-    assert 'doc-comment-form' not in ids('# documents the helper\ndef _helper(x):\n    return x\n')
+    assert 'plain-comment-on-public' not in ids('# documents the helper\ndef _helper(x):\n    return x\n')
 
 
 def test_a_public_symbol_with_a_docstring_is_fine() -> None:
-    assert 'doc-comment-form' not in ids('def build(x):\n    """Build it."""\n    return x\n')
+    assert 'plain-comment-on-public' not in ids('def build(x):\n    """Build it."""\n    return x\n')
 
 
 @pytest.mark.parametrize('tag', ['Args:', 'Returns:', 'Raises:', 'Yields:'])
 def test_a_signature_restating_tag_is_reported(tag: str) -> None:
     source = f'def build(x):\n    """Build it.\n\n    {tag}\n        x: the thing\n    """\n'
-    assert 'no-signature-restating' in ids(source)
+    assert 'signature-restating-tag' in ids(source)
 
 
 def test_the_tag_is_quoted_in_the_message() -> None:
     source = 'def build(x):\n    """Build it.\n\n    Args:\n        x: the thing\n    """\n'
-    message = next(item.message for item in lint(source).diagnostics if item.rule_id == 'no-signature-restating')
+    message = next(item.message for item in lint(source).diagnostics if item.rule_id == 'signature-restating-tag')
     assert '"Args:"' in message
 
 
@@ -62,15 +62,15 @@ def test_one_diagnostic_per_block_even_with_several_tags() -> None:
     source = (
         'def build(x):\n    """Build it.\n\n    Args:\n        x: a thing\n\n    Returns:\n        a thing\n    """\n'
     )
-    assert ids(source).count('no-signature-restating') == 1
+    assert ids(source).count('signature-restating-tag') == 1
 
 
 def test_prose_that_merely_mentions_a_tag_word_is_fine() -> None:
-    assert 'no-signature-restating' not in ids('def build(x):\n    """Build it, returns quickly."""\n    return x\n')
+    assert 'signature-restating-tag' not in ids('def build(x):\n    """Build it, returns quickly."""\n    return x\n')
 
 
 def test_a_plain_comment_is_not_checked_for_tags() -> None:
-    assert 'no-signature-restating' not in ids('def _f(x):\n    # Args: not a docstring\n    return x\n')
+    assert 'signature-restating-tag' not in ids('def _f(x):\n    # Args: not a docstring\n    return x\n')
 
 
 def test_an_overlong_line_comment_is_reported() -> None:
@@ -116,4 +116,4 @@ def test_each_rule_can_be_disabled_independently(rule_id: str) -> None:
 )
 def test_doc_comment_form_survives_decorators(decorator: str) -> None:
     source = f'# documents the public builder\n{decorator}def build(x):\n    return x\n'
-    assert 'doc-comment-form' in ids(source)
+    assert 'plain-comment-on-public' in ids(source)

--- a/tests/test_self_hosting.py
+++ b/tests/test_self_hosting.py
@@ -59,7 +59,7 @@ def test_housestyle_lints_itself_clean() -> None:
     [
         (
             'def f():\n    # cap the size so the mmap does not\n    # blow past it, an unbounded value faults.\n    pass\n',
-            'wrap-point',
+            'mid-clause-break',
         ),
         (
             'def f():\n    # this single sentence carries no comma at all and runs a very long way past any '


### PR DESCRIPTION
Three naming schemes were mixed, and two rules were named after a dimension rather than a fault. `line-width = error` invites the reasonable question of what is wrong with having a line width.

Every rule now describes its own fault, which is what ruff does with `line-too-long` and `unused-import`.

| Was | Now |
| --- | --- |
| `wrap-point` | `mid-clause-break` |
| `line-width` | `line-too-long` |
| `no-file-header` | `file-header-comment` |
| `doc-comment-form` | `plain-comment-on-public` |
| `no-signature-restating` | `signature-restating-tag` |

`stub-fragment`, `unbreakable-sentence`, and `block-too-long` already named their fault and are unchanged.

## Configuration also reads pyproject.toml

`[tool.housestyle]` is where the Python ecosystem keeps tool settings, so it works alongside `housestyle.toml`. The two layouts nest differently, so the pyproject table is reshaped before parsing:

```toml
[tool.housestyle]
line-width = 96
exclude = ["build/**"]

[tool.housestyle.rules]
mid-clause-break = false
```

A dedicated `housestyle.toml` still wins over `pyproject.toml` in the same directory, and a `pyproject.toml` without our table is skipped rather than treated as empty configuration.

## A trap worth recording

The rename hit a string that only looked like a rule name. The `line-width` **configuration key** shares its old spelling with the rule, so a blind rewrite retargeted the Pydantic alias to `line-too-long` and every configured width silently fell back to 120. Caught by a hook test, not by review.

375 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)